### PR TITLE
Support function calls on constants

### DIFF
--- a/greenplumpython/__init__.py
+++ b/greenplumpython/__init__.py
@@ -1,3 +1,3 @@
 from .db import Database, database
-from .table import Table, table, values
 from .func import function
+from .table import Table, table, values

--- a/greenplumpython/__init__.py
+++ b/greenplumpython/__init__.py
@@ -1,2 +1,3 @@
 from .db import Database, database
 from .table import Table, table, values
+from .func import function

--- a/greenplumpython/expr.py
+++ b/greenplumpython/expr.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING, Iterable, Optional
 
 if TYPE_CHECKING:
     from .db import Database
@@ -6,11 +6,8 @@ if TYPE_CHECKING:
 
 
 class Expr:
-    def __init__(self, text: str, parents: Iterable["Expr"] = [], as_name: str = None) -> None:
-        self.text = text
-        self.parents = parents
-        self.as_name = as_name
-        self.db: Database = next(iter(parents)).db
+    def __init__(self, as_name: Optional[str] = None) -> None:
+        self._as_name = as_name
 
     def __eq__(self, other):
         return BinaryExpr("=", self, other)
@@ -32,11 +29,10 @@ class BinaryExpr:
 
 
 class Column(Expr):
-    def __init__(self, name: str, table: "Table", as_name: str = None) -> None:
+    def __init__(self, name: str, table: "Table", as_name: Optional[str] = None) -> None:
         super().__init__(name, parents=[table], as_name=as_name)
-        self.table = table
-        self.name = name
-        self.db = table.db
+        self._table = table
+        self._name = name
 
     def __str__(self) -> str:
         raise NotImplementedError()

--- a/greenplumpython/func.py
+++ b/greenplumpython/func.py
@@ -8,7 +8,7 @@ from .table import Table
 
 class FunctionCall(Expr):
     def __init__(
-        self, func_name: str, db: Database, args: Iterable[Expr] = [], as_name: str = None
+        self, func_name: str, db: Database, args: Iterable[Expr] = [], as_name: Optional[str] = None
     ) -> None:
         super().__init__(as_name)
         self._func_name = func_name

--- a/greenplumpython/func.py
+++ b/greenplumpython/func.py
@@ -16,7 +16,7 @@ class FunctionCall(Expr):
         self._db = db
 
     def __str__(self) -> str:
-        args_string = ",".join([str(arg) for arg in self._args]) if self._args else ""
+        args_string = ",".join([str(arg) for arg in self._args]) if any(self._args) else ""
         return f"{self._func_name}({args_string})"
 
     def to_table(self) -> Table:

--- a/greenplumpython/func.py
+++ b/greenplumpython/func.py
@@ -1,0 +1,36 @@
+from typing import Callable, Iterable, Optional
+from uuid import uuid4
+
+from .db import Database
+from .expr import Expr
+from .table import Table
+
+
+class FunctionCall(Expr):
+    def __init__(
+        self, func_name: str, db: Database, args: Iterable[Expr] = [], as_name: str = None
+    ) -> None:
+        super().__init__(as_name)
+        self._func_name = func_name
+        self._args = args
+        self._db = db
+
+    def __str__(self) -> str:
+        args_string = ",".join([str(arg) for arg in self._args]) if self._args else ""
+        return f"{self._func_name}({args_string})"
+
+    def to_table(self) -> Table:
+        as_string = f"AS {self._as_name}" if self._as_name is not None else ""
+        ret_table = Table(f"SELECT * FROM {str(self)} {as_string}", db=self._db)
+        return Table(f"SELECT * FROM {ret_table.name}", parents=[ret_table], db=self._db)
+
+
+def function(name: str, db: Database) -> Callable[..., FunctionCall]:
+    def make_callable(*args: Expr, as_name: Optional[str] = None) -> FunctionCall:
+        return FunctionCall(name, db, args, as_name=as_name)
+
+    return make_callable
+
+
+def create_function():
+    pass

--- a/greenplumpython/table.py
+++ b/greenplumpython/table.py
@@ -88,7 +88,7 @@ class Table:
         for table in reversed(lineage):
             if table._name != self._name:
                 cte_list.append(f"{table._name} AS ({table._query})")
-        return "WITH " + ",".join(cte_list) + self.query
+        return "WITH " + ",".join(cte_list) + self._query
 
     def fetch(self, all: bool = True) -> Iterable:
         """

--- a/tests/test_const_table.py
+++ b/tests/test_const_table.py
@@ -4,7 +4,7 @@ import greenplumpython as gp
 
 
 @pytest.fixture
-def db():
+def db() -> gp.Database:
     db = gp.database(host="localhost", dbname="gpadmin")
     yield db
     db.close()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -5,5 +5,5 @@ def test_db():
     db = gp.database(host="localhost", dbname="gpadmin")
     result = db.execute("SELECT version()")
     for row in result:
-        assert "PostgreSQL" in row["version"]
+        assert "Greenplum" in row["version"]
     db.close()

--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -9,10 +9,12 @@ def db() -> gp.Database:
     yield db
     db.close()
 
+
 def test_plain_func(db: gp.Database):
     version = gp.function("version", db)
     for row in version().to_table().fetch():
         assert "Greenplum" in row["version"]
+
 
 def test_set_returning_func(db: gp.Database):
     generate_series = gp.function("generate_series", db)

--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -1,0 +1,20 @@
+import pytest
+
+import greenplumpython as gp
+
+
+@pytest.fixture
+def db() -> gp.Database:
+    db = gp.database(host="localhost", dbname="gpadmin")
+    yield db
+    db.close()
+
+def test_plain_func(db: gp.Database):
+    version = gp.function("version", db)
+    for row in version().to_table().fetch():
+        assert "Greenplum" in row["version"]
+
+def test_set_returning_func(db: gp.Database):
+    generate_series = gp.function("generate_series", db)
+    results = generate_series(0, 9, as_name="id").to_table().fetch()
+    assert sorted([row["id"] for row in results]) == list(range(10))


### PR DESCRIPTION
Being able to call functions is essential for data analytics. This
patch adds support for calling functions in Greenplum. Given
that Column is not completed when the work starts, this patch
only implements function calls on constants but not on
tables. Changes are required to support function calls on tables.