### PR TITLE
Support function calls on table columns

### DIFF
--- a/greenplumpython/expr.py
+++ b/greenplumpython/expr.py
@@ -83,6 +83,7 @@ class Column(Expr):
         self._name = name
 
     def __str__(self) -> str:
+        assert self.table is not None
         return self.table.name + "." + self.name
 
     @property

--- a/greenplumpython/expr.py
+++ b/greenplumpython/expr.py
@@ -7,9 +7,15 @@ if TYPE_CHECKING:
 
 
 class Expr:
-    def __init__(self, as_name: Optional[str] = None, db: Optional[Database] = None) -> None:
+    def __init__(
+        self,
+        as_name: Optional[str] = None,
+        table: Optional[Database] = None,
+        db: Optional[Database] = None,
+    ) -> None:
         self._as_name = as_name
-        self._db = db
+        self._table = table
+        self._db = table.db if table is not None else db
 
     def __eq__(self, other):
         if isinstance(other, type(None)):
@@ -42,6 +48,10 @@ class Expr:
     def db(self) -> Database:
         return self._db
 
+    @property
+    def table(self) -> "Table":
+        return self._table
+
 
 class BinaryExpr(Expr):
     def __init__(self, operator: str, left: Expr, right, as_name: Optional[str] = None):
@@ -66,8 +76,7 @@ class BinaryExpr(Expr):
 
 class Column(Expr):
     def __init__(self, name: str, table: "Table", as_name: Optional[str] = None) -> None:
-        super().__init__(as_name=as_name)
-        self._table = table
+        super().__init__(as_name=as_name, table=table)
         self._name = name
 
     def __str__(self) -> str:

--- a/greenplumpython/expr.py
+++ b/greenplumpython/expr.py
@@ -50,7 +50,7 @@ class Expr:
         return self._db
 
     @property
-    def table(self) -> "Table":
+    def table(self) -> Optional["Table"]:
         return self._table
 
 
@@ -88,7 +88,3 @@ class Column(Expr):
     @property
     def name(self) -> str:
         return self._name
-
-    @property
-    def table(self) -> "Table":
-        return self._table

--- a/greenplumpython/expr.py
+++ b/greenplumpython/expr.py
@@ -56,7 +56,9 @@ class Expr:
 
 class BinaryExpr(Expr):
     def __init__(self, operator: str, left: Expr, right, as_name: Optional[str] = None):
-        super().__init__(as_name=as_name)
+        table = left.table if left is not None and left.table is not None else right.table
+        db = left.db if left is not None and left.db is not None else right.db
+        super().__init__(as_name=as_name, table=table, db=db)
         self.operator = operator
         self.left = left
         self.right = right

--- a/greenplumpython/expr.py
+++ b/greenplumpython/expr.py
@@ -16,6 +16,7 @@ class Expr:
         self._as_name = as_name
         self._table = table
         self._db = table.db if table is not None else db
+        assert self._db is not None
 
     def __eq__(self, other):
         if isinstance(other, type(None)):

--- a/greenplumpython/expr.py
+++ b/greenplumpython/expr.py
@@ -10,7 +10,7 @@ class Expr:
     def __init__(
         self,
         as_name: Optional[str] = None,
-        table: Optional[Database] = None,
+        table: Optional["Table"] = None,
         db: Optional[Database] = None,
     ) -> None:
         self._as_name = as_name

--- a/greenplumpython/func.py
+++ b/greenplumpython/func.py
@@ -12,12 +12,23 @@ from .type import primitive_type_map
 
 class FunctionCall(Expr):
     def __init__(
-        self, func_name: str, db: Database, args: Iterable[Expr] = [], as_name: Optional[str] = None
+        self,
+        func_name: str,
+        args: Iterable[Expr] = [],
+        as_name: Optional[str] = None,
+        db: Optional[Database] = None,
     ) -> None:
-        super().__init__(as_name)
+        table: Optional[Table] = None
+        for arg in args:
+            if isinstance(arg, Expr) and arg.table is not None:
+                if table is None:
+                    table = arg.table
+                elif table.name != arg.table.name:
+                    raise Exception("Cannot pass arguments from more than one tables")
+        db = table.db if table is not None else db
+        super().__init__(as_name, table=table, db=db)
         self._func_name = func_name
         self._args = args
-        self._db = db
 
     def __str__(self) -> str:
         args_string = ",".join([str(arg) for arg in self._args]) if any(self._args) else ""
@@ -25,13 +36,19 @@ class FunctionCall(Expr):
 
     def to_table(self) -> Table:
         as_string = f"AS {self._as_name}" if self._as_name is not None else ""
-        ret_table = Table(f"SELECT * FROM {str(self)} {as_string}", db=self._db)
-        return Table(f"SELECT * FROM {ret_table.name}", parents=[ret_table], db=self._db)
+        from_caluse = f"FROM {self.table.name}" if self.table is not None else ""
+        parents = [self.table] if self.table is not None else []
+        orig_func_table = Table(
+            f"SELECT {str(self)} {as_string} {from_caluse}", db=self._db, parents=parents
+        )
+        return Table(
+            f"SELECT * FROM {orig_func_table.name}", parents=[orig_func_table], db=self._db
+        )
 
 
 def function(name: str, db: Database) -> Callable[..., FunctionCall]:
     def make_function_call(*args: Expr, as_name: Optional[str] = None) -> FunctionCall:
-        return FunctionCall(name, db, args, as_name=as_name)
+        return FunctionCall(name, args, as_name=as_name, db=db)
 
     return make_function_call
 
@@ -66,6 +83,7 @@ def create_function(
         func_body = "\n".join([line for line in func_lines if re.match(r"^\s", line)])
         if db is None:
             for arg in args:
+                print(arg.db)
                 if isinstance(arg, Expr) and arg.db is not None:
                     db = arg.db
                     break
@@ -81,6 +99,6 @@ def create_function(
             ),
             has_results=False,
         )
-        return FunctionCall(qualified_func_name, db, args, as_name=as_name)
+        return FunctionCall(qualified_func_name, args, as_name=as_name, db=db)
 
     return make_function_call

--- a/greenplumpython/func.py
+++ b/greenplumpython/func.py
@@ -82,7 +82,6 @@ def create_function(
         func_body = "\n".join([line for line in func_lines if re.match(r"^\s", line)])
         if db is None:
             for arg in args:
-                print(arg.db)
                 if isinstance(arg, Expr) and arg.db is not None:
                     db = arg.db
                     break

--- a/greenplumpython/func.py
+++ b/greenplumpython/func.py
@@ -25,7 +25,6 @@ class FunctionCall(Expr):
                     table = arg.table
                 elif table.name != arg.table.name:
                     raise Exception("Cannot pass arguments from more than one tables")
-        db = table.db if table is not None else db
         super().__init__(as_name, table=table, db=db)
         self._func_name = func_name
         self._args = args

--- a/greenplumpython/table.py
+++ b/greenplumpython/table.py
@@ -1,6 +1,8 @@
 from typing import Iterable, Optional, Tuple
 from uuid import uuid4
 
+from sqlalchemy import column
+
 from . import db, expr
 
 
@@ -122,8 +124,7 @@ def table(name: str, db: db.Database) -> Table:
     return Table(f"TABLE {name}", name=name, db=db)
 
 
-def values(rows: Iterable[Tuple], db: db.Database) -> Table:
-    return Table(
-        f"VALUES {','.join(['(' + ','.join(str(datum) for datum in row) + ')' for row in rows])}",
-        db=db,
-    )
+def values(rows: Iterable[Tuple], db: db.Database, column_names: Iterable[str] = []) -> Table:
+    rows_string = ",".join(["(" + ",".join(str(datum) for datum in row) + ")" for row in rows])
+    columns_string = f"({','.join(column_names)})" if any(column_names) else ""
+    return Table(f"SELECT * FROM (VALUES {rows_string}) AS vals {columns_string}", db=db)

--- a/greenplumpython/table.py
+++ b/greenplumpython/table.py
@@ -1,8 +1,6 @@
 from typing import Iterable, Optional, Tuple
 from uuid import uuid4
 
-from sqlalchemy import column
-
 from . import db, expr
 
 

--- a/greenplumpython/type.py
+++ b/greenplumpython/type.py
@@ -10,5 +10,5 @@ primitive_type_map = {
 }
 
 
-def is_primitive(type_: Type) -> bool:
+def is_primitive_type(type_: Type) -> bool:
     return type_ in primitive_type_map

--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -3,7 +3,6 @@ import inspect
 import pytest
 
 import greenplumpython as gp
-from greenplumpython.func import FunctionCall
 
 
 @pytest.fixture
@@ -62,3 +61,22 @@ def test_create_func_tab_indent(db: gp.Database):
 		assert row["result"] == min(1, 2)
 		assert row["result"] == inspect.unwrap(my_min)(1, 2)
 # fmt: on
+
+
+def test_func_on_one_column(db: gp.Database):
+    rows = [(i,) for i in range(-10, 0)]
+    series = gp.values(rows, db=db, column_names=["id"])
+    abs = gp.function("abs", db=db)
+    results = abs(series["id"]).to_table().fetch()
+    assert sorted([row["abs"] for row in results]) == list(range(1, 11))
+
+
+def test_func_on_multi_columns(db: gp.Database):
+    @gp.create_function
+    def multiply(a: int, b: int) -> int:
+        return a * b
+
+    rows = [(i, i) for i in range(10)]
+    series = gp.values(rows, db=db, column_names=["a", "b"])
+    results = multiply(series["a"], series["b"], as_name="result").to_table().fetch()
+    assert sorted([row["result"] for row in results]) == [i * i for i in range(10)]


### PR DESCRIPTION
Previously, we implemented function calls with no argument, e.g.
`version()`, and function calls on constants, e.g. `add(1, 2)`. This
patch adds support for function calls on table columns, e.g.
`SELECT multiply(t.a, t.b) FROM t`. This makes the pandas-like API
more powerful.