### PR TITLE
Support get table on slice

### DIFF
--- a/greenplumpython/table.py
+++ b/greenplumpython/table.py
@@ -66,8 +66,21 @@ class Table:
             parents=[self],
         )
 
+    @staticmethod
+    def _order_by_str(order_by: Iterable) -> str:
+        order_by_clause = (
+            f"""
+                {','.join([' '.join([col, order]) for col, order in order_by.items()])}
+            """
+            if isinstance(order_by, dict)
+            else f"""
+                    {','.join([order_index for order_index in order_by])}
+                """
+        )
+        return order_by_clause
+
     def top(self, count: int, order_by: Iterable, skip: int = 0):
-        order_by_clause = order_by_str(order_by)
+        order_by_clause = self._order_by_str(order_by)
         return Table(
             f"""
                 SELECT * FROM {self.name}
@@ -231,16 +244,3 @@ def values(rows: Iterable[Tuple], db: db.Database, column_names: Iterable[str] =
     rows_string = ",".join(["(" + ",".join(str(datum) for datum in row) + ")" for row in rows])
     columns_string = f"({','.join(column_names)})" if any(column_names) else ""
     return Table(f"SELECT * FROM (VALUES {rows_string}) AS vals {columns_string}", db=db)
-
-
-def order_by_str(order_by: Iterable) -> str:
-    order_by_clause = (
-        f"""
-            {','.join([' '.join([col, order]) for col, order in order_by.items()])}
-        """
-        if isinstance(order_by, dict)
-        else f"""
-                {','.join([order_index for order_index in order_by])}
-            """
-    )
-    return order_by_clause

--- a/greenplumpython/table.py
+++ b/greenplumpython/table.py
@@ -36,7 +36,18 @@ class Table:
         if isinstance(key, expr.Expr):
             return self.filter(key)
         if isinstance(key, slice):
-            raise NotImplementedError()
+            if key.step is not None:
+                raise NotImplementedError()
+            offset_clause = "" if key.start is None else f"OFFSET {key.start}"
+            limit_clause = (
+                ""
+                if key.stop is None
+                else f"LIMIT {key.stop if key.start is None else key.stop - key.start}"
+            )
+            return Table(
+                f"SELECT * FROM {self.name} {limit_clause} {offset_clause}",
+                parents=[self],
+            )
 
     # FIXME: Add test
     def filter(self, expr: expr.Expr) -> "Table":

--- a/tests/test_const_table.py
+++ b/tests/test_const_table.py
@@ -10,6 +10,17 @@ def db() -> gp.Database:
     db.close()
 
 
+@pytest.fixture
+def t(db: gp.Database):
+    generate_series = gp.function("generate_series", db)
+    t = (
+        generate_series(0, 9, as_name="id")
+        .to_table()
+        .save_as("temp_table", temp=True, column_names=["id"])
+    )
+    return t
+
+
 def test_const_table(db: gp.Database):
     rows = [(1,), (2,), (3,)]
     t = gp.values(rows, db=db)
@@ -30,13 +41,57 @@ def test_table_getitem_str(db: gp.Database):
     assert str(c) == (t.name + ".id")
 
 
-def test_table_getitem_slice(db: gp.Database):
-    generate_series = gp.function("generate_series", db)
-    t = (
-        generate_series(0, 9, as_name="id")
-        .to_table()
-        .save_as("temp_table", temp=True, column_names=["id"])
-    )
-    assert len(list(t[:2].fetch())) == 2
-    assert len(list(t[2:].fetch())) == 8
-    assert len(list(t[2:5].fetch())) == 3
+def test_table_order_by_str(db: gp.Database, t: gp.Table):
+    ret = t.order_by(["id"]).fetch()
+    prev = -1
+    for row in list(ret):
+        assert row["id"] == prev + 1
+        prev += 1
+
+
+def test_table_order_by_desc(db: gp.Database, t: gp.Table):
+    ret = t.order_by({"id": "DESC"}).fetch()
+    prev = 10
+    for row in list(ret):
+        assert row["id"] == prev - 1
+        prev -= 1
+
+
+def test_table_order_by_multiple(db: gp.Database):
+    # fmt: off
+    rows = [(1, 2,), (1, 3,), (2, 2,), (3, 1,), (3, 4,)]
+    # fmt: on
+    t = gp.values(rows, db=db)
+    t = t.save_as("const_table", temp=True, column_names=["id", "num"])
+    ret = t.order_by({"id": "ASC", "num": "DESC"}).fetch()
+    prev_id = 0
+    prev_num = 5
+    for row in list(ret):
+        assert row["id"] >= prev_id
+        if row["id"] == prev_id:
+            assert row["num"] <= prev_num
+        prev_id = row["id"]
+        prev_num = row["num"]
+
+
+def test_table_getitem_slice_limit(db: gp.Database, t: gp.Table):
+    ret = list(t.order_by(["id"])[:2].fetch())
+    assert len(ret) == 2
+    assert ret[0]["id"] == 0
+    assert ret[1]["id"] == 1
+
+
+def test_table_getitem_slice_offset(db: gp.Database, t: gp.Table):
+    ret = list(t.order_by(["id"])[7:].fetch())
+    assert len(ret) == 3
+    assert ret[0]["id"] == 7
+    assert ret[1]["id"] == 8
+    assert ret[2]["id"] == 9
+
+
+def test_table_getitem_slice_off_limit(db: gp.Database, t: gp.Table):
+    ret = list(t.order_by(["id"])[2:5].fetch())
+    assert len(ret) == 3
+    assert ret[0]["id"] == 2
+    assert ret[1]["id"] == 3
+    assert ret[2]["id"] == 4

--- a/tests/test_const_table.py
+++ b/tests/test_const_table.py
@@ -41,29 +41,36 @@ def test_table_getitem_str(db: gp.Database):
     assert str(c) == (t.name + ".id")
 
 
-def test_table_order_by_str(db: gp.Database, t: gp.Table):
-    ret = t.order_by(["id"]).fetch()
+def test_table_top_skip(db: gp.Database, t: gp.Table):
+    ret = list(t.top(5, ["id"], 2).fetch())
+    assert len(ret) == 5
+    assert ret[0]["id"] == 2
+    assert ret[4]["id"] == 6
+
+
+def test_table_top_str(db: gp.Database, t: gp.Table):
+    ret = t.top(10, ["id"]).fetch()
     prev = -1
     for row in list(ret):
         assert row["id"] == prev + 1
         prev += 1
 
 
-def test_table_order_by_desc(db: gp.Database, t: gp.Table):
-    ret = t.order_by({"id": "DESC"}).fetch()
+def test_table_top_desc(db: gp.Database, t: gp.Table):
+    ret = t.top(10, {"id": "DESC"}).fetch()
     prev = 10
     for row in list(ret):
         assert row["id"] == prev - 1
         prev -= 1
 
 
-def test_table_order_by_multiple(db: gp.Database):
+def test_table_top_multiple(db: gp.Database):
     # fmt: off
     rows = [(1, 2,), (1, 3,), (2, 2,), (3, 1,), (3, 4,)]
     # fmt: on
     t = gp.values(rows, db=db)
     t = t.save_as("const_table", temp=True, column_names=["id", "num"])
-    ret = t.order_by({"id": "ASC", "num": "DESC"}).fetch()
+    ret = t.top(10, {"id": "ASC", "num": "DESC"}).fetch()
     prev_id = 0
     prev_num = 5
     for row in list(ret):
@@ -75,23 +82,15 @@ def test_table_order_by_multiple(db: gp.Database):
 
 
 def test_table_getitem_slice_limit(db: gp.Database, t: gp.Table):
-    ret = list(t.order_by(["id"])[:2].fetch())
+    ret = list(t[:2].fetch())
     assert len(ret) == 2
-    assert ret[0]["id"] == 0
-    assert ret[1]["id"] == 1
 
 
 def test_table_getitem_slice_offset(db: gp.Database, t: gp.Table):
-    ret = list(t.order_by(["id"])[7:].fetch())
+    ret = list(t[7:].fetch())
     assert len(ret) == 3
-    assert ret[0]["id"] == 7
-    assert ret[1]["id"] == 8
-    assert ret[2]["id"] == 9
 
 
 def test_table_getitem_slice_off_limit(db: gp.Database, t: gp.Table):
-    ret = list(t.order_by(["id"])[2:5].fetch())
+    ret = list(t[2:5].fetch())
     assert len(ret) == 3
-    assert ret[0]["id"] == 2
-    assert ret[1]["id"] == 3
-    assert ret[2]["id"] == 4

--- a/tests/test_const_table.py
+++ b/tests/test_const_table.py
@@ -22,9 +22,21 @@ def test_const_table(db: gp.Database):
         assert row["column_name"] == "id"
 
 
-def test_table_getitem(db: gp.Database):
+def test_table_getitem_str(db: gp.Database):
     rows = [(1,), (2,), (3,)]
     t = gp.values(rows, db=db)
-    t = t.save_as("const_table", column_names=["id"])
+    t = t.save_as("const_table", column_names=["id"], temp=True)
     c = t["id"]
     assert str(c) == (t.name + ".id")
+
+
+def test_table_getitem_slice(db: gp.Database):
+    generate_series = gp.function("generate_series", db)
+    t = (
+        generate_series(0, 9, as_name="id")
+        .to_table()
+        .save_as("temp_table", column_names=["id"], temp=True)
+    )
+    assert len(list(t[:2].fetch())) == 2
+    assert len(list(t[2:].fetch())) == 8
+    assert len(list(t[2:5].fetch())) == 3


### PR DESCRIPTION
During data analysis, users may want to select a slice of the table.
This patch supports slice selection without order on Greenplum
tables using "[]", and a function table.top() which supports a 
slice selection with an order defined by user.