### PR TITLE
Support Unary Operator on Column

### DIFF
--- a/greenplumpython/expr.py
+++ b/greenplumpython/expr.py
@@ -39,16 +39,16 @@ class Expr:
         return BinaryExpr("!=", self, other)
 
     def __pos__(self):
-        return UnaryExpr("+", self)
+        return UnaryExpr("+", self, as_name='"+' + str(self) + '"')
 
     def __neg__(self):
-        return UnaryExpr("-", self)
+        return UnaryExpr("-", self, as_name='"-' + str(self) + '"')
 
     def __abs__(self):
-        return UnaryExpr("ABS", self)
+        return UnaryExpr("ABS", self, as_name='"Abs(' + str(self) + ')"')
 
     def __invert__(self):
-        return UnaryExpr("NOT", self)
+        return UnaryExpr("NOT", self, as_name='"Not(' + str(self) + ')"')
 
     def __str__(self) -> str:
         raise NotImplementedError()
@@ -93,18 +93,38 @@ class BinaryExpr(Expr):
 
 class UnaryExpr(Expr):
     def __init__(self, operator: str, right: Expr, as_name: Optional[str] = None):
-        super().__init__(as_name=as_name)
+        table = right.table
+        db = right.db
+        super().__init__(as_name=as_name, table=table, db=db)
+        if operator not in ["NOT", "ABS", "+", "-"]:
+            raise NotImplementedError(
+                f"{operator.upper()} is not a supported unary operator for Column\n"
+                f"Can only support 'NOT', 'ABS', 'POS' and 'NEG' unary operators"
+            )
         self.operator = operator
         self.right = right
 
     def __str__(self) -> str:
         if self.operator == "NOT":
-            return "NOT(" + str(self.right) + ') AS "Not(' + str(self.right) + ')"'
+            return (
+                "NOT("
+                + str(self.right)
+                + ") "
+                + ("AS " + self._as_name if self._as_name is not None else "")
+            )
         if self.operator == "ABS":
-            return "ABS(" + str(self.right) + ') AS "Abs(' + str(self.right) + ')"'
+            return (
+                "ABS("
+                + str(self.right)
+                + ") "
+                + ("AS " + self._as_name if self._as_name is not None else "")
+            )
 
         return (
-            self.operator + str(self.right) + " AS " + '"' + self.operator + str(self.right) + '"'
+            self.operator
+            + str(self.right)
+            + " "
+            + ("AS " + self._as_name if self._as_name is not None else "")
         )
 
 

--- a/greenplumpython/expr.py
+++ b/greenplumpython/expr.py
@@ -31,6 +31,18 @@ class Expr:
     def __ne__(self, other):
         return BinaryExpr("!=", self, other)
 
+    def __pos__(self):
+        return UnaryExpr("+", self)
+
+    def __neg__(self):
+        return UnaryExpr("-", self)
+
+    def __abs__(self):
+        return UnaryExpr("ABS", self)
+
+    def __invert__(self):
+        return UnaryExpr("NOT", self)
+
     def __str__(self) -> str:
         raise NotImplementedError()
 
@@ -62,6 +74,23 @@ class BinaryExpr(Expr):
                 return str(self.left) + " " + self.operator + " FALSE"
 
         return str(self.left) + " " + self.operator + " " + str(self.right)
+
+
+class UnaryExpr(Expr):
+    def __init__(self, operator: str, right: Expr, as_name: Optional[str] = None):
+        super().__init__(as_name=as_name)
+        self.operator = operator
+        self.right = right
+
+    def __str__(self) -> str:
+        if self.operator == "NOT":
+            return "NOT(" + str(self.right) + ') AS "Not(' + str(self.right) + ')"'
+        if self.operator == "ABS":
+            return "ABS(" + str(self.right) + ') AS "Abs(' + str(self.right) + ')"'
+
+        return (
+            self.operator + str(self.right) + " AS " + '"' + self.operator + str(self.right) + '"'
+        )
 
 
 class Column(Expr):

--- a/tests/test_binaryExpr.py
+++ b/tests/test_binaryExpr.py
@@ -12,7 +12,7 @@ def db():
 
 def test_expr_bin_equal_int(db: gp.Database):
     rows = [(1,), (2,), (3,), (2,)]
-    t = gp.values(rows, db=db).save_as("temp1", column_names=["id"])
+    t = gp.values(rows, db=db).save_as("temp1", column_names=["id"], temp=True)
     b1 = t["id"] == 2
     assert str(b1) == str(gp.expr.BinaryExpr("=", t["id"], 2))
     assert str(b1) == "temp1.id = 2"
@@ -22,7 +22,7 @@ def test_expr_bin_equal_int(db: gp.Database):
 
 def test_expr_bin_equal_str(db: gp.Database):
     rows = [("'aaa'",), ("'bbb'",), ("'ccc'",)]
-    t = gp.values(rows, db=db).save_as("temp2", column_names=["id"])
+    t = gp.values(rows, db=db).save_as("temp2", column_names=["id"], temp=True)
     b2 = t["id"] == "aaa"
     assert str(b2) == str(gp.expr.BinaryExpr("=", t["id"], "aaa"))
     assert str(b2) == "temp2.id = 'aaa'"
@@ -32,7 +32,7 @@ def test_expr_bin_equal_str(db: gp.Database):
 
 def test_expr_bin_equal_none(db: gp.Database):
     rows = [("'aa'",), ("NULL",), ("'cc'",)]
-    t = gp.values(rows, db=db).save_as("temp3", column_names=["id"])
+    t = gp.values(rows, db=db).save_as("temp3", column_names=["id"], temp=True)
     b3 = t["id"] == None
     assert str(b3) == str(gp.expr.BinaryExpr("is", t["id"], None))
     assert str(b3) == "temp3.id is NULL"
@@ -43,8 +43,8 @@ def test_expr_bin_equal_none(db: gp.Database):
 # TODO : Add Query Condition Test for JOIN
 def test_expr_bin_equal_2expr(db: gp.Database):
     rows = [(1,), (2,), (3,), (2,)]
-    t1 = gp.values(rows, db=db).save_as("temp4", column_names=["id"])
-    t2 = gp.values(rows, db=db).save_as("temp5", column_names=["id"])
+    t1 = gp.values(rows, db=db).save_as("temp4", column_names=["id"], temp=True)
+    t2 = gp.values(rows, db=db).save_as("temp5", column_names=["id"], temp=True)
     b4 = t1["id"] == t2["id"]
     assert str(b4) == str(gp.expr.BinaryExpr("=", t1["id"], t2["id"]))
     assert str(b4) == "temp4.id = temp5.id"
@@ -52,7 +52,7 @@ def test_expr_bin_equal_2expr(db: gp.Database):
 
 def test_expr_bin_equal_bool(db: gp.Database):
     rows = [("True",), ("False",), ("False",), ("True",)]
-    t = gp.values(rows, db=db).save_as("temp1", column_names=["id"])
+    t = gp.values(rows, db=db).save_as("temp1", column_names=["id"], temp=True)
     b5 = t["id"] == True
     assert str(b5) == "temp1.id = TRUE"
     ret = t[b5].fetch()

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -38,3 +38,7 @@ def test_expr_column_str_in_query(db: gp.Database, table: gp.Table):
         keys = list(row.keys())
         assert len(keys) == 1
         assert "id" in keys[0]
+
+
+def test_expr_column_rename(db: gp.Database, table: gp.Table):
+    assert str(table["id"].rename("table_id")) == "const_table.id AS table_id"

--- a/tests/test_unaryExpr.py
+++ b/tests/test_unaryExpr.py
@@ -13,7 +13,7 @@ def db():
 def test_expr_unary_not(db: gp.Database):
     rows = [("True",), ("False",), ("True",), ("True",)]
     t = gp.values(rows, db=db).save_as("temp1", column_names=["id"], temp=True)
-    b1 = ~t["id"]
+    b1 = (~t["id"]).rename('"Not(temp1.id)"')
     assert str(b1) == 'NOT(temp1.id) AS "Not(temp1.id)"'
     ret = list(t[["id", str(b1)]].fetch())
     for row in ret:
@@ -25,7 +25,7 @@ def test_expr_unary_not(db: gp.Database):
 def test_expr_unary_pos(db: gp.Database):
     rows = [(-1,), (-2,), (-3,), (-2,)]
     t = gp.values(rows, db=db).save_as("temp2", column_names=["id"], temp=True)
-    b2 = +t["id"]
+    b2 = (+t["id"]).rename('"+temp2.id"')
     assert str(b2) == '+temp2.id AS "+temp2.id"'
     ret = list(t[["id", str(b2)]].fetch())
     for row in ret:
@@ -35,7 +35,7 @@ def test_expr_unary_pos(db: gp.Database):
 def test_expr_unary_neg(db: gp.Database):
     rows = [(1,), (2,), (3,), (2,)]
     t = gp.values(rows, db=db).save_as("temp3", column_names=["id"], temp=True)
-    b3 = -t["id"]
+    b3 = (-t["id"]).rename('"-temp3.id"')
     assert str(b3) == '-temp3.id AS "-temp3.id"'
     ret = list(t[["id", str(b3)]].fetch())
     for row in ret:
@@ -45,7 +45,7 @@ def test_expr_unary_neg(db: gp.Database):
 def test_expr_unary_abs(db: gp.Database):
     rows = [(1,), (-2,), (-3,), (2,)]
     t = gp.values(rows, db=db).save_as("temp4", column_names=["id"], temp=True)
-    b4 = abs(t["id"])
+    b4 = abs(t["id"]).rename('"Abs(temp4.id)"')
     assert str(b4) == 'ABS(temp4.id) AS "Abs(temp4.id)"'
     ret = list(t[["id", str(b4)]].fetch())
     for row in ret:

--- a/tests/test_unaryExpr.py
+++ b/tests/test_unaryExpr.py
@@ -50,3 +50,12 @@ def test_expr_unary_abs(db: gp.Database):
     ret = list(t[["id", str(b4)]].fetch())
     for row in ret:
         assert row["Abs(temp4.id)"] == abs(row["id"])
+
+
+def test_expr_unary_unsupport(db: gp.Database):
+    rows = [(1,), (2,), (3,), (4,)]
+    t = gp.values(rows, db=db).save_as("temp5", column_names=["id"], temp=True)
+    with pytest.raises(
+        NotImplementedError, match=r"Can only support 'NOT', 'ABS', 'POS' and 'NEG' unary operators"
+    ):
+        gp.expr.UnaryExpr("!", t["id"])

--- a/tests/test_unaryExpr.py
+++ b/tests/test_unaryExpr.py
@@ -1,0 +1,52 @@
+import pytest
+
+import greenplumpython as gp
+
+
+@pytest.fixture
+def db():
+    db = gp.database(host="localhost", dbname="postgres")
+    yield db
+    db.close()
+
+
+def test_expr_unary_not(db: gp.Database):
+    rows = [("True",), ("False",), ("True",), ("True",)]
+    t = gp.values(rows, db=db).save_as("temp1", column_names=["id"], temp=True)
+    b1 = ~t["id"]
+    assert str(b1) == 'NOT(temp1.id) AS "Not(temp1.id)"'
+    ret = list(t[["id", str(b1)]].fetch())
+    for row in ret:
+        bool_id = row["id"]
+        bool_id_not = row["Not(temp1.id)"]
+        assert bool_id ^ bool_id_not
+
+
+def test_expr_unary_pos(db: gp.Database):
+    rows = [(-1,), (-2,), (-3,), (-2,)]
+    t = gp.values(rows, db=db).save_as("temp2", column_names=["id"], temp=True)
+    b2 = +t["id"]
+    assert str(b2) == '+temp2.id AS "+temp2.id"'
+    ret = list(t[["id", str(b2)]].fetch())
+    for row in ret:
+        assert row["+temp2.id"] == +(row["id"])
+
+
+def test_expr_unary_neg(db: gp.Database):
+    rows = [(1,), (2,), (3,), (2,)]
+    t = gp.values(rows, db=db).save_as("temp3", column_names=["id"], temp=True)
+    b3 = -t["id"]
+    assert str(b3) == '-temp3.id AS "-temp3.id"'
+    ret = list(t[["id", str(b3)]].fetch())
+    for row in ret:
+        assert row["-temp3.id"] == -(row["id"])
+
+
+def test_expr_unary_abs(db: gp.Database):
+    rows = [(1,), (-2,), (-3,), (2,)]
+    t = gp.values(rows, db=db).save_as("temp4", column_names=["id"], temp=True)
+    b4 = abs(t["id"])
+    assert str(b4) == 'ABS(temp4.id) AS "Abs(temp4.id)"'
+    ret = list(t[["id", str(b4)]].fetch())
+    for row in ret:
+        assert row["Abs(temp4.id)"] == abs(row["id"])

--- a/tests/test_unaryExpr.py
+++ b/tests/test_unaryExpr.py
@@ -5,7 +5,7 @@ import greenplumpython as gp
 
 @pytest.fixture
 def db():
-    db = gp.database(host="localhost", dbname="postgres")
+    db = gp.database(host="localhost", dbname="gpadmin")
     yield db
     db.close()
 


### PR DESCRIPTION
- Make table in test_binaryExpr.py temporary
- support not(), abs(), pos(), neg()
- Add tests
- TODO :
  * Integrate unary operator in table.__getitem__
  * Probably need to change how to do unary_operator_column name alias