### PR TITLE
Support creating and calling array functions

### DIFF
--- a/greenplumpython/__init__.py
+++ b/greenplumpython/__init__.py
@@ -1,3 +1,9 @@
 from .db import Database, database
-from .func import aggregate, create_aggregate, create_function, function
+from .func import (
+    aggregate,
+    create_aggregate,
+    create_array_function,
+    create_function,
+    function,
+)
 from .table import Table, table, values

--- a/greenplumpython/expr.py
+++ b/greenplumpython/expr.py
@@ -58,14 +58,14 @@ class Expr:
         return UnaryExpr("NOT", self)
 
     def __str__(self) -> str:
-        return self._sql_str() + (" AS " + self._as_name if self._as_name is not None else "")
+        return self._serialize() + (" AS " + self._as_name if self._as_name is not None else "")
 
     def rename(self, new_name: str) -> "Expr":
         new_expr = copy.copy(self)  # Shallow copy
         new_expr._as_name = new_name
         return new_expr
 
-    def _sql_str(self) -> str:
+    def _serialize(self) -> str:
         raise NotImplementedError()
 
     @property
@@ -90,7 +90,7 @@ class BinaryExpr(Expr):
         self.left = left
         self.right = right
 
-    def _sql_str(self) -> str:
+    def _serialize(self) -> str:
         if isinstance(self.right, type(None)):
             return str(self.left) + " " + self.operator + " " + "NULL"
         if isinstance(self.right, str):
@@ -119,7 +119,7 @@ class UnaryExpr(Expr):
         self.operator = operator
         self.right = right
 
-    def _sql_str(self) -> str:
+    def _serialize(self) -> str:
         if self.operator == "NOT":
             return "NOT(" + str(self.right) + ")"
         if self.operator == "ABS":
@@ -133,7 +133,7 @@ class Column(Expr):
         super().__init__(as_name=as_name, table=table)
         self._name = name
 
-    def _sql_str(self) -> str:
+    def _serialize(self) -> str:
         assert self.table is not None
         return self.table.name + "." + self.name
 

--- a/greenplumpython/type.py
+++ b/greenplumpython/type.py
@@ -13,6 +13,7 @@ primitive_type_map = {
 # FIXME: Annotate the argument type for this function
 def to_pg_type(annotation) -> str:
     if hasattr(annotation, "__origin__"):
+        print("Origin =", annotation.__origin__)
         if annotation.__origin__ == typing.List:
             return f"{to_pg_type(annotation.__args__[0])}[]"
         raise NotImplementedError()

--- a/greenplumpython/type.py
+++ b/greenplumpython/type.py
@@ -13,8 +13,9 @@ primitive_type_map = {
 # FIXME: Annotate the argument type for this function
 def to_pg_type(annotation) -> str:
     if hasattr(annotation, "__origin__"):
-        print("Origin =", annotation.__origin__)
-        if annotation.__origin__ == typing.List:
+        # The `or` here is to make the function work on Python 3.6.
+        # Python 3.6 is the default Python version on CentOS 7 and Ubuntu 18.04
+        if annotation.__origin__ == list or annotation.__origin__ == typing.List:
             return f"{to_pg_type(annotation.__args__[0])}[]"
         raise NotImplementedError()
     else:

--- a/greenplumpython/type.py
+++ b/greenplumpython/type.py
@@ -1,4 +1,4 @@
-from typing import GenericMeta, List
+import typing
 
 primitive_type_map = {
     None: "void",
@@ -12,11 +12,11 @@ primitive_type_map = {
 
 # FIXME: Annotate the argument type for this function
 def to_pg_type(annotation) -> str:
-    if not isinstance(annotation, GenericMeta):
+    if not isinstance(annotation, typing.GenericMeta):
         if annotation in primitive_type_map:
             return primitive_type_map[annotation]
-        return NotImplementedError()  # TODO: Support composite types
+        raise NotImplementedError()  # TODO: Support composite types
     else:
-        if annotation.__origin__ == List:
+        if annotation.__origin__ == typing.List:
             return f"{to_pg_type(annotation.__args__[0])}[]"
-        return NotImplementedError()
+        raise NotImplementedError()

--- a/greenplumpython/type.py
+++ b/greenplumpython/type.py
@@ -1,4 +1,4 @@
-from typing import Type
+from typing import GenericMeta, List
 
 primitive_type_map = {
     None: "void",
@@ -10,5 +10,13 @@ primitive_type_map = {
 }
 
 
-def is_primitive_type(type_: Type) -> bool:
-    return type_ in primitive_type_map
+# FIXME: Annotate the argument type for this function
+def to_pg_type(annotation) -> str:
+    if not isinstance(annotation, GenericMeta):
+        if annotation in primitive_type_map:
+            return primitive_type_map[annotation]
+        return NotImplementedError()  # TODO: Support composite types
+    else:
+        if annotation.__origin__ == List:
+            return f"{to_pg_type(annotation.__args__[0])}[]"
+        return NotImplementedError()

--- a/greenplumpython/type.py
+++ b/greenplumpython/type.py
@@ -12,11 +12,11 @@ primitive_type_map = {
 
 # FIXME: Annotate the argument type for this function
 def to_pg_type(annotation) -> str:
-    if not isinstance(annotation, typing.GenericMeta):
-        if annotation in primitive_type_map:
-            return primitive_type_map[annotation]
-        raise NotImplementedError()  # TODO: Support composite types
-    else:
+    if hasattr(annotation, "__origin__"):
         if annotation.__origin__ == typing.List:
             return f"{to_pg_type(annotation.__args__[0])}[]"
         raise NotImplementedError()
+    else:
+        if annotation in primitive_type_map:
+            return primitive_type_map[annotation]
+        raise NotImplementedError()  # TODO: Support composite types


### PR DESCRIPTION
Array functions take arrays as arguments. Before calling the
function, each attribute in the rows will be aggregated as an
array and passed to the function. In this way, the function can
have access to the attribute in all rows in the same call. This 
makes it possible for the user to do complex analytics and for
the PL handler to optimize the performance.