### PR TITLE
feat: support centos7 and ubuntu18 for CI

### DIFF
--- a/concourse/pipeline/dev.yml
+++ b/concourse/pipeline/dev.yml
@@ -2,6 +2,7 @@
 #@   "entrance_job",
 #@   "build_test_job",
 #@   "centos7_gpdb6_conf",
+#@   "ubuntu18_gpdb6_conf",
 #@   "rhel8_gpdb6_conf")
 #@
 #@ load("trigger_def.lib.yml",

--- a/concourse/pipeline/job_def.lib.yml
+++ b/concourse/pipeline/job_def.lib.yml
@@ -5,7 +5,7 @@
 #! Job config for centos7
 #@ def centos7_gpdb6_conf(release_build=False):
 res_test_image: centos7-gpdb6-image-test
-res_gpdb_bin: bin_gpdb6_centos7_debug
+res_gpdb_bin: bin_gpdb6_centos7
 res_gpdb_src: gpdb6_src
 res_plpython3_bin: bin_plpython3_gpdb6_rhel7
 os: rhel7
@@ -14,10 +14,19 @@ os: rhel7
 #! Job config for rhel8
 #@ def rhel8_gpdb6_conf(release_build=False):
 res_test_image: rhel8-gpdb6-image-test
-res_gpdb_bin: bin_gpdb6_rhel8_debug
+res_gpdb_bin: bin_gpdb6_rhel8
 res_gpdb_src: gpdb6_src
 res_plpython3_bin: bin_plpython3_gpdb6_rhel8
 os: rhel8
+#@ end
+
+#! Job config for ubuntu18
+#@ def ubuntu18_gpdb6_conf(release_build=False):
+res_test_image: ubuntu18-gpdb6-image-test
+res_gpdb_bin: bin_gpdb6_ubuntu18
+res_gpdb_src: gpdb6_src
+res_plpython3_bin: bin_plpython3_gpdb6_ubuntu18
+os: ubuntu1804
 #@ end
 
 #! The entry point of a pipeline. The job name must be 'entrance'.

--- a/concourse/pipeline/res_def.yml
+++ b/concourse/pipeline/res_def.yml
@@ -71,22 +71,37 @@ resources:
     tag: latest
     username: _json_key
     password: ((container-registry-readonly-service-account-key))
+# ubuntu18
+- name: ubuntu18-gpdb6-image-test
+  type: registry-image
+  source:
+    repository: gcr.io/data-gpdb-public-images/gpdb6-ubuntu18.04-test
+    tag: latest
+    username: _json_key
+    password: ((container-registry-readonly-service-account-key))
 
 # gpdb binary on gcs is located as different folder for different version
 # Latest build with assertion enabled:
 # --enable-cassert --enable-tap-tests --enable-debug-extensions
-- name: bin_gpdb6_centos7_debug
+- name: bin_gpdb6_centos7
   type: gcs
   source:
     bucket: ((gcs-bucket))
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/published/gpdb6/server-rc-(.*)-rhel7_x86_64.debug.tar.gz
-- name: bin_gpdb6_rhel8_debug
+    regexp: server/published/gpdb6/server-rc-(.*)-rhel7_x86_64.tar.gz
+- name: bin_gpdb6_rhel8
   type: gcs
   source:
     bucket: ((gcs-bucket))
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/published/gpdb6/server-rc-(.*)-rhel8_x86_64.debug.tar.gz
+    regexp: server/published/gpdb6/server-rc-(.*)-rhel8_x86_64.tar.gz
+
+- name: bin_gpdb6_ubuntu18
+  type: gcs
+  source:
+    bucket: ((gcs-bucket))
+    json_key: ((concourse-gcs-resources-service-account-key))
+    regexp: server/published/gpdb6/server-rc-(.*)-ubuntu18.04_x86_64.tar.gz
 
 # plpython3 for gpdb6
 - name: bin_plpython3_gpdb6_rhel7
@@ -101,6 +116,12 @@ resources:
     bucket: gpdb-extensions-concourse-resources
     json_key: ((extensions-gcs-service-account-key))
     versioned_file: intermediates/plpython3/plpython3_rhel8_gpdb6.gppkg
+- name: bin_plpython3_gpdb6_ubuntu18
+  type: gcs
+  source:
+    bucket: gpdb-extensions-concourse-resources
+    json_key: ((extensions-gcs-service-account-key))
+    versioned_file: intermediates/plpython3/plpython3_ubuntu18.04_gpdb6.gppkg
 
 # Other dependencies
 - name: slack_notify


### PR DESCRIPTION
1. support centos7 and ubuntu18 pipeline
2. change all `bin_gpdb_debug` to `bin_gpdb`
3. for the `plpyton3` install python3.9 reason need to install `pip` using `get-pip.py` for install tox and other requirements 