### PR TITLE
Override arithmetic operators for `Expr`

### DIFF
--- a/doc/source/expr.rst
+++ b/doc/source/expr.rst
@@ -4,6 +4,6 @@ Expression
 .. automodule:: expr
    :members:
    :undoc-members:
-   :special-members: __and__, __or__, __eq__, __lt__, __le__, __gt__, __ge__, __ne__, __mod__, __pos__, __neg__, __abs__, __invert__, __add__, __sub__, __mul__
+   :special-members: __and__, __or__, __eq__, __lt__, __le__, __gt__, __ge__, __ne__, __mod__, __pos__, __neg__, __abs__, __invert__, __add__, __sub__, __mul__, __truediv__
    :show-inheritance:
    :member-order: bysource

--- a/doc/source/expr.rst
+++ b/doc/source/expr.rst
@@ -4,6 +4,6 @@ Expression
 .. automodule:: expr
    :members:
    :undoc-members:
-   :special-members: __and__, __or__, __eq__, __lt__, __le__, __gt__, __ge__, __ne__, __mod__, __pos__, __neg__, __abs__, __invert__
+   :special-members: __and__, __or__, __eq__, __lt__, __le__, __gt__, __ge__, __ne__, __mod__, __pos__, __neg__, __abs__, __invert__, __add__, __sub__, __mul__
    :show-inheritance:
    :member-order: bysource

--- a/doc/source/notebooks/basic.ipynb
+++ b/doc/source/notebooks/basic.ipynb
@@ -938,13 +938,6 @@
     "\n",
     "my_sum(numbers[\"val\"], as_name=\"result\", db=db).to_table()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/greenplumpython/expr.py
+++ b/greenplumpython/expr.py
@@ -191,6 +191,20 @@ class Expr:
         """
         return BinaryExpr("*", self, other)
 
+    def __truediv__(self, other: Any) -> "Expr":
+        """
+        Operator **/**
+
+        Returns a Binary Expression Division between an :class:`Expr` and another :class:`Expr` or constant.
+        It results integer division between two integers, and true division if one of the arguments is a float.
+
+        Example:
+            .. code-block::  Python
+
+                t["val"] / 2
+        """
+        return BinaryExpr("/", self, other)
+
     def __pos__(self) -> "Expr":
         """
         Operator **+**

--- a/greenplumpython/expr.py
+++ b/greenplumpython/expr.py
@@ -139,11 +139,11 @@ class Expr:
         """
         return BinaryExpr("!=", self, other)
 
-    def __mod__(self, other: Union[int, "Expr"]) -> "Expr":
+    def __mod__(self, other: "Expr") -> "Expr":
         """
         Operator **%**
 
-        Returns a Binary Expression Modulo between an :class:`Expr` and an integer or an :class:`Expr`
+        Returns a Binary Expression Modulo between an :class:`Expr` and another an :class:`Expr`
 
         Example:
             .. code-block::  Python
@@ -151,6 +151,45 @@ class Expr:
                 t["val"] % 2
         """
         return BinaryExpr("%", self, other)
+
+    def __add__(self, other: "Expr") -> "Expr":
+        """
+        Operator **+**
+
+        Returns a Binary Expression Addition between an :class:`Expr` and another an :class:`Expr`
+
+        Example:
+            .. code-block::  Python
+
+                t["val"] + 2
+        """
+        return BinaryExpr("+", self, other)
+
+    def __sub__(self, other: "Expr") -> "Expr":
+        """
+        Operator **-**
+
+        Returns a Binary Expression Subtraction between an :class:`Expr` and another an :class:`Expr`
+
+        Example:
+            .. code-block::  Python
+
+                t["val"] - 2
+        """
+        return BinaryExpr("-", self, other)
+
+    def __mul__(self, other: "Expr") -> "Expr":
+        """
+        Operator *****
+
+        Returns a Binary Expression Multiplication between an :class:`Expr` and another an :class:`Expr`
+
+        Example:
+            .. code-block::  Python
+
+                t["val"] * 2
+        """
+        return BinaryExpr("*", self, other)
 
     def __pos__(self) -> "Expr":
         """

--- a/greenplumpython/expr.py
+++ b/greenplumpython/expr.py
@@ -32,11 +32,11 @@ class Expr:
         self._table = table
         self._db = table.db if table is not None else db
 
-    def __and__(self, other: "Expr") -> "Expr":
+    def __and__(self, other: Any) -> "Expr":
         """
         Operator **&**
 
-        Returns a Binary Expression AND between self and another :class:`Expr`
+        Returns a Binary Expression AND between self and another :class:`Expr` or constant
 
         Example:
             .. code-block::  Python
@@ -46,11 +46,11 @@ class Expr:
         """
         return BinaryExpr("AND", self, other)
 
-    def __or__(self, other: "Expr") -> "Expr":
+    def __or__(self, other: Any) -> "Expr":
         """
         Operator **|**
 
-        Returns a Binary Expression OR between self and another :class:`Expr`
+        Returns a Binary Expression OR between self and another :class:`Expr` or constant
 
         Example:
             .. code-block::  Python
@@ -59,11 +59,11 @@ class Expr:
         """
         return BinaryExpr("OR", self, other)
 
-    def __eq__(self, other: "Expr") -> "Expr":
+    def __eq__(self, other: Any) -> "Expr":
         """
         Operator **==**
 
-        Returns a Binary Expression EQUAL between self and another :class:`Expr`
+        Returns a Binary Expression EQUAL between self and another :class:`Expr` or constant
 
         Example:
             .. code-block::  Python
@@ -74,11 +74,11 @@ class Expr:
             return BinaryExpr("is", self, other)
         return BinaryExpr("=", self, other)
 
-    def __lt__(self, other: "Expr") -> "Expr":
+    def __lt__(self, other: Any) -> "Expr":
         """
         Operator **<**
 
-        Returns a Binary Expression LESS THAN between self and another :class:`Expr`
+        Returns a Binary Expression LESS THAN between self and another :class:`Expr` or constant
 
         Example:
             .. code-block::  Python
@@ -87,11 +87,11 @@ class Expr:
         """
         return BinaryExpr("<", self, other)
 
-    def __le__(self, other: "Expr") -> "Expr":
+    def __le__(self, other: Any) -> "Expr":
         """
         Operator **<=**
 
-        Returns a Binary Expression LESS EQUAL between self and another :class:`Expr`
+        Returns a Binary Expression LESS EQUAL between self and another :class:`Expr` or constant
 
         Example:
             .. code-block::  Python
@@ -100,11 +100,11 @@ class Expr:
         """
         return BinaryExpr("<=", self, other)
 
-    def __gt__(self, other: "Expr") -> "Expr":
+    def __gt__(self, other: Any) -> "Expr":
         """
         Operator **>**
 
-        Returns a Binary Expression GREATER THAN between self and another :class:`Expr`
+        Returns a Binary Expression GREATER THAN between self and another :class:`Expr` or constant
 
         Example:
             .. code-block::  Python
@@ -113,11 +113,11 @@ class Expr:
         """
         return BinaryExpr(">", self, other)
 
-    def __ge__(self, other: "Expr") -> "Expr":
+    def __ge__(self, other: Any) -> "Expr":
         """
         Operator **>=**
 
-        Returns a Binary Expression GREATER EQUAL between self and another :class:`Expr`
+        Returns a Binary Expression GREATER EQUAL between self and another :class:`Expr` or constant
 
         Example:
             .. code-block::  Python
@@ -126,11 +126,11 @@ class Expr:
         """
         return BinaryExpr(">=", self, other)
 
-    def __ne__(self, other: "Expr") -> "Expr":
+    def __ne__(self, other: Any) -> "Expr":
         """
         Operator **!=**
 
-        Returns a Binary Expression NOT EQUAL between self and another :class:`Expr`
+        Returns a Binary Expression NOT EQUAL between self and another :class:`Expr` or constant
 
         Example:
             .. code-block::  Python
@@ -139,11 +139,11 @@ class Expr:
         """
         return BinaryExpr("!=", self, other)
 
-    def __mod__(self, other: "Expr") -> "Expr":
+    def __mod__(self, other: Any) -> "Expr":
         """
         Operator **%**
 
-        Returns a Binary Expression Modulo between an :class:`Expr` and another an :class:`Expr`
+        Returns a Binary Expression Modulo between an :class:`Expr` and another :class:`Expr` or constant
 
         Example:
             .. code-block::  Python
@@ -152,11 +152,11 @@ class Expr:
         """
         return BinaryExpr("%", self, other)
 
-    def __add__(self, other: "Expr") -> "Expr":
+    def __add__(self, other: Any) -> "Expr":
         """
         Operator **+**
 
-        Returns a Binary Expression Addition between an :class:`Expr` and another an :class:`Expr`
+        Returns a Binary Expression Addition between an :class:`Expr` and another :class:`Expr` or constant
 
         Example:
             .. code-block::  Python
@@ -165,11 +165,11 @@ class Expr:
         """
         return BinaryExpr("+", self, other)
 
-    def __sub__(self, other: "Expr") -> "Expr":
+    def __sub__(self, other: Any) -> "Expr":
         """
         Operator **-**
 
-        Returns a Binary Expression Subtraction between an :class:`Expr` and another an :class:`Expr`
+        Returns a Binary Expression Subtraction between an :class:`Expr` and another :class:`Expr` or constant
 
         Example:
             .. code-block::  Python
@@ -178,11 +178,11 @@ class Expr:
         """
         return BinaryExpr("-", self, other)
 
-    def __mul__(self, other: "Expr") -> "Expr":
+    def __mul__(self, other: Any) -> "Expr":
         """
         Operator *****
 
-        Returns a Binary Expression Multiplication between an :class:`Expr` and another an :class:`Expr`
+        Returns a Binary Expression Multiplication between an :class:`Expr` and another :class:`Expr` or constant
 
         Example:
             .. code-block::  Python

--- a/tests/test_binaryExpr.py
+++ b/tests/test_binaryExpr.py
@@ -178,6 +178,6 @@ def test_table_true_div_integer_float(db: gp.Database):
 def test_table_true_div_zero(db: gp.Database):
     nums = gp.values([(i,) for i in range(5)], db, column_names=["num"])
     with pytest.raises(Exception) as exc_info:
-        nums.extend("div", nums["num"] / nums["num"])
+        nums.extend("div", nums["num"] / nums["num"]).fetch()
 
-    assert "division by zero" == str(exc_info.value)
+    assert "division by zero\n" == str(exc_info.value)

--- a/tests/test_binaryExpr.py
+++ b/tests/test_binaryExpr.py
@@ -148,3 +148,36 @@ def test_table_mul(db: gp.Database):
 
     for row in results.fetch():
         assert row["num"] ** 2 == row["mul"]
+
+
+def test_table_true_div(db: gp.Database):
+    nums = gp.values([(i,) for i in range(1, 10)], db, column_names=["num"])
+    results = nums.extend("div", nums["num"] / nums["num"])
+
+    for row in results.fetch():
+        assert row["div"] == 1
+
+
+def test_table_true_div_integers(db: gp.Database):
+    nums = gp.values([(i,) for i in range(4, 5)], db, column_names=["num"])
+    results = nums.extend("div", nums["num"] / 2)
+
+    for row in results.fetch():
+        assert row["div"] == 2
+
+
+def test_table_true_div_integer_float(db: gp.Database):
+    nums = gp.values([(i,) for i in range(4, 5)], db, column_names=["num"])
+    float_type = gp.get_type("float", db)
+    results = nums.extend("div", float_type(nums["num"]) / 2)
+
+    for row in results.fetch():
+        assert row["div"] == 2 or row["div"] == 2.5
+
+
+def test_table_true_div_zero(db: gp.Database):
+    nums = gp.values([(i,) for i in range(5)], db, column_names=["num"])
+    with pytest.raises(Exception) as exc_info:
+        nums.extend("div", nums["num"] / nums["num"])
+
+    assert "division by zero" == str(exc_info.value)

--- a/tests/test_binaryExpr.py
+++ b/tests/test_binaryExpr.py
@@ -167,12 +167,12 @@ def test_table_true_div_integers(db: gp.Database):
 
 
 def test_table_true_div_integer_float(db: gp.Database):
-    nums = gp.values([(i,) for i in range(4, 5)], db, column_names=["num"])
+    nums = gp.values([(i,) for i in range(5, 8, 2)], db, column_names=["num"])
     float_type = gp.get_type("float", db)
     results = nums.extend("div", float_type(nums["num"]) / 2)
 
     for row in results.fetch():
-        assert row["div"] == 2 or row["div"] == 2.5
+        assert row["div"] == 2.5 or row["div"] == 3.5
 
 
 def test_table_true_div_zero(db: gp.Database):

--- a/tests/test_binaryExpr.py
+++ b/tests/test_binaryExpr.py
@@ -124,3 +124,27 @@ def test_table_like(db: gp.Database):
     assert len(list(result)) == 1
     result = t[t["id"].like(r"_a%")].fetch()
     assert len(list(result)) == 1
+
+
+def test_table_add(db: gp.Database):
+    nums = gp.values([(i,) for i in range(10)], db, column_names=["num"])
+    results = nums.extend("add", nums["num"] + 1)
+
+    for row in results.fetch():
+        assert row["num"] + 1 == row["add"]
+
+
+def test_table_sub(db: gp.Database):
+    nums = gp.values([(i,) for i in range(10)], db, column_names=["num"])
+    results = nums.extend("sub", nums["num"] - 1)
+
+    for row in results.fetch():
+        assert row["num"] - 1 == row["sub"]
+
+
+def test_table_mul(db: gp.Database):
+    nums = gp.values([(i,) for i in range(10)], db, column_names=["num"])
+    results = nums.extend("mul", nums["num"] * nums["num"])
+
+    for row in results.fetch():
+        assert row["num"] ** 2 == row["mul"]


### PR DESCRIPTION
This patch overrides 3 arithmetic operators for `Expr`: add, sub and mul.