### PR TITLE
Fix error when displaying table with no results

### DIFF
--- a/greenplumpython/table.py
+++ b/greenplumpython/table.py
@@ -148,30 +148,33 @@ class Table:
         # FIXME : adjust columns width depending on the number of characters
         repr_string = ""
         ret = list(self.fetch())
-        repr_string += (("| {:10} |" * len(ret[0])).format(*ret[0])) + "\n"
-        repr_string += ("=" * 14 * len(ret[0])) + "\n"
-        for row in ret:
-            content = [row[c] for c in row]
-            for c in content:
-                if isinstance(c, list):
-                    repr_string += ("| {:10} |").format("{}".format(c))  # type: ignore
-                else:
-                    repr_string += ("| {:10} |").format(c)
-            repr_string += "\n"
+        if len(ret) != 0:
+            repr_string += (("| {:10} |" * len(ret[0])).format(*ret[0])) + "\n"
+            repr_string += ("=" * 14 * len(ret[0])) + "\n"
+            for row in ret:
+                content = [row[c] for c in row]
+                for c in content:
+                    if isinstance(c, list):
+                        repr_string += ("| {:10} |").format("{}".format(c))  # type: ignore
+                    else:
+                        repr_string += ("| {:10} |").format(c)
+                repr_string += "\n"
         return repr_string
 
     def _repr_html_(self):
         ret = list(self.fetch())
-        repr_html_str = "<table>\n"
-        repr_html_str += "\t<tr>\n"
-        repr_html_str += ("\t\t<th>{:}</th>\n" * len(ret[0])).format(*ret[0])
-        repr_html_str += "\t</tr>\n"
-        for row in ret:
+        repr_html_str = ""
+        if len(ret) != 0:
+            repr_html_str = "<table>\n"
             repr_html_str += "\t<tr>\n"
-            content = [row[c] for c in row]
-            repr_html_str += ("\t\t<td>{:}</td>\n" * len(row)).format(*content)
+            repr_html_str += ("\t\t<th>{:}</th>\n" * len(ret[0])).format(*ret[0])
             repr_html_str += "\t</tr>\n"
-        repr_html_str += "</table>"
+            for row in ret:
+                repr_html_str += "\t<tr>\n"
+                content = [row[c] for c in row]
+                repr_html_str += ("\t\t<td>{:}</td>\n" * len(row)).format(*content)
+                repr_html_str += "\t</tr>\n"
+            repr_html_str += "</table>"
         return repr_html_str
 
     def rename(self, name: str) -> "Table":

--- a/greenplumpython/table.py
+++ b/greenplumpython/table.py
@@ -145,19 +145,30 @@ class Table:
         """
         Return a string representation for a table
         """
-        # FIXME : adjust columns width depending on the number of characters
         repr_string = ""
         ret = list(self.fetch())
         if len(ret) != 0:
-            repr_string += (("| {:10} |" * len(ret[0])).format(*ret[0])) + "\n"
-            repr_string += ("=" * 14 * len(ret[0])) + "\n"
+            # Iterate over the given table to calculate the column width for its ASCII representation.
+            width = [0] * len(ret[0])
+            for row in ret:
+                for col_idx, col in enumerate(row):
+                    width[col_idx] = max(width[col_idx], len(col), len(str(row[col])))
+
+            # Table header.
+            repr_string += (
+                "".join(["| {:{}} |".format(col, width[idx]) for idx, col in enumerate(ret[0])])
+                + "\n"
+            )
+            # Dividing line below table header.
+            repr_string += ("=" * (sum(width) + 4 * len(width))) + "\n"
+            # Table contents.
             for row in ret:
                 content = [row[c] for c in row]
-                for c in content:
+                for idx, c in enumerate(content):
                     if isinstance(c, list):
-                        repr_string += ("| {:10} |").format("{}".format(c))  # type: ignore
+                        repr_string += ("| {:{}} |").format("{}".format(c), width[idx])  # type: ignore
                     else:
-                        repr_string += ("| {:10} |").format(c)
+                        repr_string += ("| {:{}} |").format(c, width[idx])
                 repr_string += "\n"
         return repr_string
 

--- a/tests/test_const_table.py
+++ b/tests/test_const_table.py
@@ -121,6 +121,15 @@ def test_table_display_repr_html(db: gp.Database):
     assert (t.order_by(t["id"]).head(4)._repr_html_()) == expected
 
 
+def test_table_display_repr_empty_result(db: gp.Database):
+    # fmt: off
+    rows = [(1, "Lion",), (2, "Tiger",), (3, "Wolf",), (4, "Fox")]
+    # fmt: on
+    t = gp.values(rows, db=db, column_names=["id", "animal"])
+    assert str(t[t["id"] == 0]) == ""
+    assert (t[t["id"] == 0]._repr_html_()) == ""
+
+
 def test_table_extend_const(db: gp.Database):
     nums = gp.values([(i,) for i in range(10)], db, column_names=["num"])
     results = nums.extend("x", "hello").fetch()

--- a/tests/test_const_table.py
+++ b/tests/test_const_table.py
@@ -63,12 +63,12 @@ def test_table_display_repr(db: gp.Database):
     # fmt: on
     t = gp.values(rows, db=db, column_names=["id", "animal"])
     expected = (
-        "| id         || animal     |\n"
-        "============================\n"
-        "|          1 || Lion       |\n"
-        "|          2 || Tiger      |\n"
-        "|          3 || Wolf       |\n"
-        "|          4 || Fox        |\n"
+        "| id || animal |\n"
+        "================\n"
+        "|  1 || Lion   |\n"
+        "|  2 || Tiger  |\n"
+        "|  3 || Wolf   |\n"
+        "|  4 || Fox    |\n"
     )
     assert str(t.order_by(t["id"]).head(4)) == expected
 
@@ -79,12 +79,12 @@ def test_table_display_repr_long_content(db: gp.Database):
     # fmt: on
     t = gp.values(rows, db=db, column_names=["iddddddddddddddddddd", "animal"])
     expected = (
-        "| iddddddddddddddddddd || animal     |\n"
-        "============================\n"
-        "|          1 || Lion       |\n"
-        "|          2 || Tigerrrrrrrrrrrr |\n"
-        "|          3 || Wolf       |\n"
-        "|          4 || Fox        |\n"
+        "| iddddddddddddddddddd || animal           |\n"
+        "============================================\n"
+        "|                    1 || Lion             |\n"
+        "|                    2 || Tigerrrrrrrrrrrr |\n"
+        "|                    3 || Wolf             |\n"
+        "|                    4 || Fox              |\n"
     )
     assert str(t.order_by(t["iddddddddddddddddddd"]).head(4)) == expected
 


### PR DESCRIPTION
This patch fixes errors when `print(table)` for table's query has no results.