### PR TITLE
Fix CI psycopg2 problem

### DIFF
--- a/concourse/scripts/entry.sh
+++ b/concourse/scripts/entry.sh
@@ -152,6 +152,8 @@ function setup_gpadmin_bashrc() {
         echo "source /home/gpadmin/gpdb_src/gpAux/gpdemo/gpdemo-env.sh"
         echo "export OS_NAME=${OS_NAME}"
         echo "export PATH=\$PATH:${GPHOME}/ext/python3.9/bin"
+        # psycopg2 needs Python.h
+        echo "export CFLAGS=-I/usr/local/greenplum-db-devel/ext/python3.9/include/python3.9"
     } >> /home/gpadmin/.bashrc
 }
 


### PR DESCRIPTION
The gpdb testing image removed python3 since there is a vendored python3
in the gdpb release now. To install psycopg2, the Python.h needs to be
in the include path.
