### PR TITLE
Assign func with composite type

### DIFF
--- a/greenplumpython/db.py
+++ b/greenplumpython/db.py
@@ -41,7 +41,6 @@ class Database:
 
         """
         with self._conn.cursor() as cursor:
-            print(query)
             cursor.execute(query)
             if has_results:
                 column_names = [desc[0] for desc in cursor.description]

--- a/greenplumpython/db.py
+++ b/greenplumpython/db.py
@@ -41,6 +41,7 @@ class Database:
 
         """
         with self._conn.cursor() as cursor:
+            print(query)
             cursor.execute(query)
             if has_results:
                 column_names = [desc[0] for desc in cursor.description]

--- a/greenplumpython/row.py
+++ b/greenplumpython/row.py
@@ -1,6 +1,8 @@
 """
 This module creates a Python object Row for table iteration.
 """
+import collections
+import json
 from typing import Any, List
 
 from psycopg2.extras import RealDictRow
@@ -12,7 +14,22 @@ class Row:
     """
 
     def __init__(self, contents: RealDictRow):
-        self._contents = contents
+
+        def detect_duplicate_keys(json_pairs):
+            key_count = collections.Counter(k for k, v in json_pairs)
+            duplicate_keys = ", ".join(k for k, v in key_count.items() if v > 1)
+
+            if len(duplicate_keys) > 0:
+                raise Exception("Duplicate key(s) found: {}".format(duplicate_keys))
+
+        def validate_data(json_pairs):
+            detect_duplicate_keys(json_pairs)
+            return dict(json_pairs)
+
+        if "to_json" in contents:
+            self._contents = json.loads(contents["to_json"], object_pairs_hook=validate_data)
+        else:
+            self._contents = contents
 
     def __getitem__(self, name: str) -> Any:
         return self._contents[name]

--- a/greenplumpython/row.py
+++ b/greenplumpython/row.py
@@ -14,15 +14,14 @@ class Row:
     """
 
     def __init__(self, contents: RealDictRow):
-
-        def detect_duplicate_keys(json_pairs):
-            key_count = collections.Counter(k for k, v in json_pairs)
+        def detect_duplicate_keys(json_pairs: List[tuple[str, Any]]):
+            key_count = collections.Counter(k for k, _ in json_pairs)
             duplicate_keys = ", ".join(k for k, v in key_count.items() if v > 1)
 
             if len(duplicate_keys) > 0:
                 raise Exception("Duplicate key(s) found: {}".format(duplicate_keys))
 
-        def validate_data(json_pairs):
+        def validate_data(json_pairs: List[tuple[str, Any]]):
             detect_duplicate_keys(json_pairs)
             return dict(json_pairs)
 

--- a/tests/test_const_table.py
+++ b/tests/test_const_table.py
@@ -148,6 +148,15 @@ def test_table_assign_expr(db: gp.Database):
         assert row["result"] == row["num"] + 1
 
 
+def test_table_assign_same_column_name(db: gp.Database):
+
+    nums = gp.values([(i,) for i in range(10)], db, column_names=["num"])
+    with pytest.raises(Exception) as exc_info:
+        results = nums.assign(num=lambda nums: add_one(nums["num"]))
+        next(iter(results))
+    assert str(exc_info.value) == "Duplicate key(s) found: num"
+
+
 def test_table_assign_composite_type(db: gp.Database):
     class rank_label:
         val: int

--- a/tests/test_const_table.py
+++ b/tests/test_const_table.py
@@ -133,10 +133,12 @@ def test_table_assign_const(db: gp.Database):
         assert "num" in row and "x" in row and row["x"] == "hello"
 
 
+@gp.create_function
+def add_one(num: int) -> int:
+    return num + 1
+
+
 def test_table_assign_expr(db: gp.Database):
-    @gp.create_function
-    def add_one(num: int) -> int:
-        return num + 1
 
     nums = gp.values([(i,) for i in range(10)], db, column_names=["num"])
     # FIXME: How to remove the intermdeiate variable `nums`?
@@ -144,6 +146,28 @@ def test_table_assign_expr(db: gp.Database):
     results = nums.assign(result=lambda nums: add_one(nums["num"]))
     for row in results:
         assert row["result"] == row["num"] + 1
+
+
+def test_table_assign_composite_type(db: gp.Database):
+    class rank_label:
+        val: int
+        label: str
+
+    @gp.create_function
+    def my_count_sum(val: int) -> rank_label:
+        return {"val": val, "label": "label"}
+
+    nums = gp.values([(i,) for i in range(10)], db, column_names=["num"])
+    results = nums.assign(result=lambda nums: my_count_sum(nums["num"]))
+    results = results.assign(result2=lambda nums: my_count_sum(nums["num"]))
+    results = results.assign(next_val=lambda nums: add_one(nums["num"]))
+    for row in results:
+        assert row["num"] == row["result"]["val"] and row["result"]["label"] == "label"
+        assert (
+            row["result2"]["val"] == row["result"]["val"]
+            and row["result2"]["label"] == row["result"]["label"]
+        )
+        assert row["next_val"] == row["num"] + 1
 
 
 def test_table_assign_same_base(db: gp.Database):

--- a/tests/test_const_table.py
+++ b/tests/test_const_table.py
@@ -154,12 +154,12 @@ def test_table_assign_composite_type(db: gp.Database):
         label: str
 
     @gp.create_function
-    def my_count_sum(val: int) -> rank_label:
+    def my_rank_label(val: int) -> rank_label:
         return {"val": val, "label": "label"}
 
     nums = gp.values([(i,) for i in range(10)], db, column_names=["num"])
-    results = nums.assign(result=lambda nums: my_count_sum(nums["num"]))
-    results = results.assign(result2=lambda nums: my_count_sum(nums["num"]))
+    results = nums.assign(result=lambda nums: my_rank_label(nums["num"]))
+    results = results.assign(result2=lambda nums: my_rank_label(nums["num"]))
     results = results.assign(next_val=lambda nums: add_one(nums["num"]))
     for row in results:
         assert row["num"] == row["result"]["val"] and row["result"]["label"] == "label"


### PR DESCRIPTION
`Table.assign()` with functions returning more than one column returns
a **string of list** containing all of these columns, which results in impossibility 
to access  column by key. This patch changes the format of return to a dictionary,
row of a composite type after `assign()` looks like:
`{"result": {"sub_field_1": smt, "sub_field_2": smt}}`