### PR TITLE
Resupport `apply()` function

### DIFF
--- a/doc/source/notebooks/GreenplumPython-abalone.ipynb
+++ b/doc/source/notebooks/GreenplumPython-abalone.ipynb
@@ -69,9 +69,7 @@
     },
     {
      "data": {
-      "text/plain": [
-       "[]"
-      ]
+      "text/plain": "[]"
      },
      "execution_count": 2,
      "metadata": {},
@@ -117,9 +115,7 @@
     },
     {
      "data": {
-      "text/plain": [
-       "[]"
-      ]
+      "text/plain": "[]"
      },
      "execution_count": 3,
      "metadata": {},
@@ -180,9 +176,7 @@
     },
     {
      "data": {
-      "text/plain": [
-       "[]"
-      ]
+      "text/plain": "[]"
      },
      "execution_count": 4,
      "metadata": {},
@@ -297,99 +291,12 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<table>\n",
-       "\t<tr>\n",
-       "\t\t<th>id</th>\n",
-       "\t\t<th>sex</th>\n",
-       "\t\t<th>length</th>\n",
-       "\t\t<th>diameter</th>\n",
-       "\t\t<th>height</th>\n",
-       "\t\t<th>whole_weight</th>\n",
-       "\t\t<th>shucked_weight</th>\n",
-       "\t\t<th>viscera_weight</th>\n",
-       "\t\t<th>shell_weight</th>\n",
-       "\t\t<th>rings</th>\n",
-       "\t</tr>\n",
-       "\t<tr>\n",
-       "\t\t<td>1</td>\n",
-       "\t\t<td>M</td>\n",
-       "\t\t<td>0.455</td>\n",
-       "\t\t<td>0.365</td>\n",
-       "\t\t<td>0.095</td>\n",
-       "\t\t<td>0.514</td>\n",
-       "\t\t<td>0.2245</td>\n",
-       "\t\t<td>0.101</td>\n",
-       "\t\t<td>0.15</td>\n",
-       "\t\t<td>15</td>\n",
-       "\t</tr>\n",
-       "\t<tr>\n",
-       "\t\t<td>2</td>\n",
-       "\t\t<td>M</td>\n",
-       "\t\t<td>0.35</td>\n",
-       "\t\t<td>0.265</td>\n",
-       "\t\t<td>0.09</td>\n",
-       "\t\t<td>0.2255</td>\n",
-       "\t\t<td>0.0995</td>\n",
-       "\t\t<td>0.0485</td>\n",
-       "\t\t<td>0.07</td>\n",
-       "\t\t<td>7</td>\n",
-       "\t</tr>\n",
-       "\t<tr>\n",
-       "\t\t<td>3</td>\n",
-       "\t\t<td>F</td>\n",
-       "\t\t<td>0.53</td>\n",
-       "\t\t<td>0.42</td>\n",
-       "\t\t<td>0.135</td>\n",
-       "\t\t<td>0.677</td>\n",
-       "\t\t<td>0.2565</td>\n",
-       "\t\t<td>0.1415</td>\n",
-       "\t\t<td>0.21</td>\n",
-       "\t\t<td>9</td>\n",
-       "\t</tr>\n",
-       "\t<tr>\n",
-       "\t\t<td>4</td>\n",
-       "\t\t<td>M</td>\n",
-       "\t\t<td>0.44</td>\n",
-       "\t\t<td>0.365</td>\n",
-       "\t\t<td>0.125</td>\n",
-       "\t\t<td>0.516</td>\n",
-       "\t\t<td>0.2155</td>\n",
-       "\t\t<td>0.114</td>\n",
-       "\t\t<td>0.155</td>\n",
-       "\t\t<td>10</td>\n",
-       "\t</tr>\n",
-       "\t<tr>\n",
-       "\t\t<td>5</td>\n",
-       "\t\t<td>I</td>\n",
-       "\t\t<td>0.33</td>\n",
-       "\t\t<td>0.255</td>\n",
-       "\t\t<td>0.08</td>\n",
-       "\t\t<td>0.205</td>\n",
-       "\t\t<td>0.0895</td>\n",
-       "\t\t<td>0.0395</td>\n",
-       "\t\t<td>0.055</td>\n",
-       "\t\t<td>7</td>\n",
-       "\t</tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "| id         || sex        || length     || diameter   || height     || whole_weight || shucked_weight || viscera_weight || shell_weight || rings      |\n",
-       "============================================================================================================================================\n",
-       "|          1 || M          ||      0.455 ||      0.365 ||      0.095 ||      0.514 ||     0.2245 ||      0.101 ||       0.15 ||         15 |\n",
-       "|          2 || M          ||       0.35 ||      0.265 ||       0.09 ||     0.2255 ||     0.0995 ||     0.0485 ||       0.07 ||          7 |\n",
-       "|          3 || F          ||       0.53 ||       0.42 ||      0.135 ||      0.677 ||     0.2565 ||     0.1415 ||       0.21 ||          9 |\n",
-       "|          4 || M          ||       0.44 ||      0.365 ||      0.125 ||      0.516 ||     0.2155 ||      0.114 ||      0.155 ||         10 |\n",
-       "|          5 || I          ||       0.33 ||      0.255 ||       0.08 ||      0.205 ||     0.0895 ||     0.0395 ||      0.055 ||          7 |"
-      ]
+      "text/plain": "| id || sex || length || diameter || height || whole_weight || shucked_weight || viscera_weight || shell_weight || rings |\n==========================================================================================================================\n|  1 || M   ||  0.455 ||    0.365 ||  0.095 ||        0.514 ||         0.2245 ||          0.101 ||         0.15 ||    15 |\n|  2 || M   ||   0.35 ||    0.265 ||   0.09 ||       0.2255 ||         0.0995 ||         0.0485 ||         0.07 ||     7 |\n|  3 || F   ||   0.53 ||     0.42 ||  0.135 ||        0.677 ||         0.2565 ||         0.1415 ||         0.21 ||     9 |\n|  4 || M   ||   0.44 ||    0.365 ||  0.125 ||        0.516 ||         0.2155 ||          0.114 ||        0.155 ||    10 |\n|  5 || I   ||   0.33 ||    0.255 ||   0.08 ||        0.205 ||         0.0895 ||         0.0395 ||        0.055 ||     7 |",
+      "text/html": "<table>\n\t<tr>\n\t\t<th>id</th>\n\t\t<th>sex</th>\n\t\t<th>length</th>\n\t\t<th>diameter</th>\n\t\t<th>height</th>\n\t\t<th>whole_weight</th>\n\t\t<th>shucked_weight</th>\n\t\t<th>viscera_weight</th>\n\t\t<th>shell_weight</th>\n\t\t<th>rings</th>\n\t</tr>\n\t<tr>\n\t\t<td>1</td>\n\t\t<td>M</td>\n\t\t<td>0.455</td>\n\t\t<td>0.365</td>\n\t\t<td>0.095</td>\n\t\t<td>0.514</td>\n\t\t<td>0.2245</td>\n\t\t<td>0.101</td>\n\t\t<td>0.15</td>\n\t\t<td>15</td>\n\t</tr>\n\t<tr>\n\t\t<td>2</td>\n\t\t<td>M</td>\n\t\t<td>0.35</td>\n\t\t<td>0.265</td>\n\t\t<td>0.09</td>\n\t\t<td>0.2255</td>\n\t\t<td>0.0995</td>\n\t\t<td>0.0485</td>\n\t\t<td>0.07</td>\n\t\t<td>7</td>\n\t</tr>\n\t<tr>\n\t\t<td>3</td>\n\t\t<td>F</td>\n\t\t<td>0.53</td>\n\t\t<td>0.42</td>\n\t\t<td>0.135</td>\n\t\t<td>0.677</td>\n\t\t<td>0.2565</td>\n\t\t<td>0.1415</td>\n\t\t<td>0.21</td>\n\t\t<td>9</td>\n\t</tr>\n\t<tr>\n\t\t<td>4</td>\n\t\t<td>M</td>\n\t\t<td>0.44</td>\n\t\t<td>0.365</td>\n\t\t<td>0.125</td>\n\t\t<td>0.516</td>\n\t\t<td>0.2155</td>\n\t\t<td>0.114</td>\n\t\t<td>0.155</td>\n\t\t<td>10</td>\n\t</tr>\n\t<tr>\n\t\t<td>5</td>\n\t\t<td>I</td>\n\t\t<td>0.33</td>\n\t\t<td>0.255</td>\n\t\t<td>0.08</td>\n\t\t<td>0.205</td>\n\t\t<td>0.0895</td>\n\t\t<td>0.0395</td>\n\t\t<td>0.055</td>\n\t\t<td>7</td>\n\t</tr>\n</table>"
      },
      "execution_count": 8,
      "metadata": {},
@@ -399,7 +306,7 @@
    "source": [
     "# SELECT * FROM abalone ORDER BY id LIMIT 5;\n",
     "\n",
-    "abalone.order_by(abalone[\"id\"]).head(5)"
+    "abalone.order_by(\"id\")[:5]"
    ]
   },
   {
@@ -412,36 +319,12 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<table>\n",
-       "\t<tr>\n",
-       "\t\t<th>count</th>\n",
-       "\t\t<th>gp_segment_id</th>\n",
-       "\t</tr>\n",
-       "\t<tr>\n",
-       "\t\t<td>1307</td>\n",
-       "\t\t<td>2</td>\n",
-       "\t</tr>\n",
-       "\t<tr>\n",
-       "\t\t<td>2870</td>\n",
-       "\t\t<td>1</td>\n",
-       "\t</tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "| count      || gp_segment_id |\n",
-       "============================\n",
-       "|       1307 ||          2 |\n",
-       "|       2870 ||          1 |"
-      ]
+      "text/plain": "| count || gp_segment_id |\n==========================\n|  1307 ||             2 |\n|  2870 ||             1 |",
+      "text/html": "<table>\n\t<tr>\n\t\t<th>count</th>\n\t\t<th>gp_segment_id</th>\n\t</tr>\n\t<tr>\n\t\t<td>1307</td>\n\t\t<td>2</td>\n\t</tr>\n\t<tr>\n\t\t<td>2870</td>\n\t\t<td>1</td>\n\t</tr>\n</table>"
      },
      "execution_count": 9,
      "metadata": {},
@@ -456,7 +339,7 @@
     "\n",
     "import greenplumpython.builtin.function as F\n",
     "\n",
-    "abalone.group_by(\"gp_segment_id\").apply(lambda _: F.count()).to_table()"
+    "abalone.group_by(\"gp_segment_id\").apply(lambda _: F.count())"
    ]
   },
   {
@@ -469,15 +352,11 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "abalone_train = gp.table(\"abalone_train\", db)\n",
-    "abalone_test = gp.table(\"abalone_test\", db)"
+    "abalone_train = db.table(\"abalone_train\")\n",
+    "abalone_test = db.table(\"abalone_test\")"
    ]
   },
   {
@@ -568,11 +447,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# DROP TABLE IF EXISTS plc_linreg_fitted;\n",
@@ -598,8 +473,7 @@
     "\n",
     "linreg_fitted = (\n",
     "    abalone_train.group_by(\"sex\")\n",
-    "    .apply(lambda t: linreg_func(t[\"length\"], t[\"shucked_weight\"], t[\"rings\"]))\n",
-    "    .to_table()\n",
+    "    .apply(lambda t: linreg_func(t[\"length\"], t[\"shucked_weight\"], t[\"rings\"]), expand=True)\n",
     ")"
    ]
   },
@@ -625,45 +499,8 @@
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<table>\n",
-       "\t<tr>\n",
-       "\t\t<th>sex</th>\n",
-       "\t\t<th>col_nm</th>\n",
-       "\t\t<th>coef</th>\n",
-       "\t\t<th>intercept</th>\n",
-       "\t\t<th>created_dt</th>\n",
-       "\t</tr>\n",
-       "\t<tr>\n",
-       "\t\t<td>F</td>\n",
-       "\t\t<td>['length', 'shucked_weight']</td>\n",
-       "\t\t<td>[24.849936356088897, -7.829448311767511]</td>\n",
-       "\t\t<td>0.21748556932817742</td>\n",
-       "\t\t<td>2022-08-31 15:31:07.193186</td>\n",
-       "\t</tr>\n",
-       "\t<tr>\n",
-       "\t\t<td>M</td>\n",
-       "\t\t<td>['length', 'shucked_weight']</td>\n",
-       "\t\t<td>[21.901123322160092, -5.89547811353611]</td>\n",
-       "\t\t<td>0.8898115753242095</td>\n",
-       "\t\t<td>2022-08-31 15:31:07.193090</td>\n",
-       "\t</tr>\n",
-       "\t<tr>\n",
-       "\t\t<td>I</td>\n",
-       "\t\t<td>['length', 'shucked_weight']</td>\n",
-       "\t\t<td>[15.43767935437459, 0.5125315282409975]</td>\n",
-       "\t\t<td>1.1574382350035979</td>\n",
-       "\t\t<td>2022-08-31 15:31:07.194423</td>\n",
-       "\t</tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "| sex        || col_nm     || coef       || intercept  || created_dt |\n",
-       "======================================================================\n",
-       "| F          || ['length', 'shucked_weight'] || [24.849936356088897, -7.829448311767511] || 0.21748556932817742 || 2022-08-31 15:31:07.168933 |\n",
-       "| M          || ['length', 'shucked_weight'] || [21.901123322160092, -5.89547811353611] || 0.8898115753242095 || 2022-08-31 15:31:07.184359 |\n",
-       "| I          || ['length', 'shucked_weight'] || [15.43767935437459, 0.5125315282409975] || 1.1574382350035979 || 2022-08-31 15:31:07.185913 |"
-      ]
+      "text/plain": "| sex || col_nm                       || coef                                      || intercept           || created_dt                 |\n=========================================================================================================================================\n| F   || ['length', 'shucked_weight'] || [26.677442247064107, -8.82714442267337]   || -0.4057486055590189 || 2022-10-27 16:22:03.644497 |\n| M   || ['length', 'shucked_weight'] || [23.79156650268057, -6.710275877764344]   || 0.24256983316982428 || 2022-10-27 16:22:03.646051 |\n| I   || ['length', 'shucked_weight'] || [15.834671804214807, 0.39462829105464065] ||    1.09533145597959 || 2022-10-27 16:22:03.648077 |",
+      "text/html": "<table>\n\t<tr>\n\t\t<th>sex</th>\n\t\t<th>col_nm</th>\n\t\t<th>coef</th>\n\t\t<th>intercept</th>\n\t\t<th>created_dt</th>\n\t</tr>\n\t<tr>\n\t\t<td>F</td>\n\t\t<td>['length', 'shucked_weight']</td>\n\t\t<td>[26.677442247064107, -8.82714442267337]</td>\n\t\t<td>-0.4057486055590189</td>\n\t\t<td>2022-10-27 16:22:03.644497</td>\n\t</tr>\n\t<tr>\n\t\t<td>M</td>\n\t\t<td>['length', 'shucked_weight']</td>\n\t\t<td>[23.79156650268057, -6.710275877764344]</td>\n\t\t<td>0.24256983316982428</td>\n\t\t<td>2022-10-27 16:22:03.646051</td>\n\t</tr>\n\t<tr>\n\t\t<td>I</td>\n\t\t<td>['length', 'shucked_weight']</td>\n\t\t<td>[15.834671804214807, 0.39462829105464065]</td>\n\t\t<td>1.09533145597959</td>\n\t\t<td>2022-10-27 16:22:03.648077</td>\n\t</tr>\n</table>"
      },
      "execution_count": 13,
      "metadata": {},
@@ -698,81 +535,13 @@
    "cell_type": "code",
    "execution_count": 14,
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "collapsed": false
    },
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<table>\n",
-       "\t<tr>\n",
-       "\t\t<th>sex</th>\n",
-       "\t\t<th>col_nm</th>\n",
-       "\t\t<th>coef</th>\n",
-       "\t</tr>\n",
-       "\t<tr>\n",
-       "\t\t<td>F</td>\n",
-       "\t\t<td>length</td>\n",
-       "\t\t<td>24.849936356088904</td>\n",
-       "\t</tr>\n",
-       "\t<tr>\n",
-       "\t\t<td>F</td>\n",
-       "\t\t<td>shucked_weight</td>\n",
-       "\t\t<td>-7.829448311767513</td>\n",
-       "\t</tr>\n",
-       "\t<tr>\n",
-       "\t\t<td>F</td>\n",
-       "\t\t<td>intercept</td>\n",
-       "\t\t<td>0.21748556932817387</td>\n",
-       "\t</tr>\n",
-       "\t<tr>\n",
-       "\t\t<td>M</td>\n",
-       "\t\t<td>length</td>\n",
-       "\t\t<td>21.901123322160092</td>\n",
-       "\t</tr>\n",
-       "\t<tr>\n",
-       "\t\t<td>M</td>\n",
-       "\t\t<td>shucked_weight</td>\n",
-       "\t\t<td>-5.89547811353611</td>\n",
-       "\t</tr>\n",
-       "\t<tr>\n",
-       "\t\t<td>M</td>\n",
-       "\t\t<td>intercept</td>\n",
-       "\t\t<td>0.8898115753242095</td>\n",
-       "\t</tr>\n",
-       "\t<tr>\n",
-       "\t\t<td>I</td>\n",
-       "\t\t<td>length</td>\n",
-       "\t\t<td>15.437679354374595</td>\n",
-       "\t</tr>\n",
-       "\t<tr>\n",
-       "\t\t<td>I</td>\n",
-       "\t\t<td>shucked_weight</td>\n",
-       "\t\t<td>0.5125315282409966</td>\n",
-       "\t</tr>\n",
-       "\t<tr>\n",
-       "\t\t<td>I</td>\n",
-       "\t\t<td>intercept</td>\n",
-       "\t\t<td>1.157438235003596</td>\n",
-       "\t</tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "| sex        || col_nm     || coef       |\n",
-       "==========================================\n",
-       "| F          || length     || 24.849936356088904 |\n",
-       "| F          || shucked_weight || -7.829448311767514 |\n",
-       "| F          || intercept  || 0.21748556932817742 |\n",
-       "| M          || length     || 21.901123322160085 |\n",
-       "| M          || shucked_weight || -5.89547811353611 |\n",
-       "| M          || intercept  || 0.8898115753242131 |\n",
-       "| I          || length     || 15.43767935437459 |\n",
-       "| I          || shucked_weight || 0.5125315282409999 |\n",
-       "| I          || intercept  || 1.157438235003597 |"
-      ]
+      "text/plain": "| sex || col_nm2        || coef2               |\n================================================\n| F   || length         ||  26.677442247064107 |\n| F   || shucked_weight ||   -8.82714442267337 |\n| F   || intercept      || -0.4057486055590189 |\n| M   || length         ||   23.79156650268057 |\n| M   || shucked_weight ||  -6.710275877764344 |\n| M   || intercept      || 0.24256983316982428 |\n| I   || length         ||  15.834671804214807 |\n| I   || shucked_weight || 0.39462829105464065 |\n| I   || intercept      ||    1.09533145597959 |",
+      "text/html": "<table>\n\t<tr>\n\t\t<th>sex</th>\n\t\t<th>col_nm2</th>\n\t\t<th>coef2</th>\n\t</tr>\n\t<tr>\n\t\t<td>F</td>\n\t\t<td>length</td>\n\t\t<td>26.677442247064107</td>\n\t</tr>\n\t<tr>\n\t\t<td>F</td>\n\t\t<td>shucked_weight</td>\n\t\t<td>-8.82714442267337</td>\n\t</tr>\n\t<tr>\n\t\t<td>F</td>\n\t\t<td>intercept</td>\n\t\t<td>-0.4057486055590189</td>\n\t</tr>\n\t<tr>\n\t\t<td>M</td>\n\t\t<td>length</td>\n\t\t<td>23.79156650268057</td>\n\t</tr>\n\t<tr>\n\t\t<td>M</td>\n\t\t<td>shucked_weight</td>\n\t\t<td>-6.710275877764344</td>\n\t</tr>\n\t<tr>\n\t\t<td>M</td>\n\t\t<td>intercept</td>\n\t\t<td>0.24256983316982428</td>\n\t</tr>\n\t<tr>\n\t\t<td>I</td>\n\t\t<td>length</td>\n\t\t<td>15.834671804214807</td>\n\t</tr>\n\t<tr>\n\t\t<td>I</td>\n\t\t<td>shucked_weight</td>\n\t\t<td>0.39462829105464065</td>\n\t</tr>\n\t<tr>\n\t\t<td>I</td>\n\t\t<td>intercept</td>\n\t\t<td>1.09533145597959</td>\n\t</tr>\n</table>"
      },
      "execution_count": 14,
      "metadata": {},
@@ -787,14 +556,12 @@
     "# from linreg_fitted;\n",
     "\n",
     "unnest = gp.function(\"unnest\")\n",
-    "\n",
     "array_append = gp.function(\"array_append\")\n",
     "\n",
-    "linreg_fitted.select(\n",
-    "    linreg_fitted[\"sex\"],\n",
-    "    unnest(array_append(linreg_fitted[\"col_nm\"], \"intercept\")).rename(\"col_nm\"),\n",
-    "    unnest(array_append(linreg_fitted[\"coef\"], linreg_fitted[\"intercept\"])).rename(\"coef\"),\n",
-    ")"
+    "linreg_fitted.assign(\n",
+    "    col_nm2=lambda t: unnest(array_append(t[\"col_nm\"], \"intercept\")),\n",
+    "    coef2=lambda t: unnest(array_append(t[\"coef\"], t[\"intercept\"])),\n",
+    ")[[\"sex\", \"col_nm2\", \"coef2\"]]"
    ]
   },
   {
@@ -852,24 +619,15 @@
    "cell_type": "code",
    "execution_count": 16,
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "collapsed": false
    },
    "outputs": [],
    "source": [
     "linreg_test_fit = linreg_fitted.inner_join(\n",
     "    abalone_test,\n",
-    "    cond=linreg_fitted[\"sex\"] == abalone_test[\"sex\"],\n",
-    "    targets=[\n",
-    "        linreg_fitted[\"col_nm\"],\n",
-    "        linreg_fitted[\"coef\"],\n",
-    "        linreg_fitted[\"intercept\"],\n",
-    "        linreg_fitted[\"serialized_linreg_model\"],\n",
-    "        linreg_fitted[\"created_dt\"],\n",
-    "        abalone_test[\"*\"],\n",
-    "    ],\n",
+    "    cond=lambda t1, t2: t1[\"sex\"] == t2[\"sex\"],\n",
+    "    self_columns=[\"col_nm\", \"coef\", \"intercept\", \"serialized_linreg_model\", \"created_dt\"],\n",
+    "    other_columns=[\"*\"],\n",
     ")"
    ]
   },
@@ -888,11 +646,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# CREATE TABLE plc_linreg_pred_dot AS (\n",
@@ -912,13 +666,13 @@
     "# ) DISTRIBUTED BY (sex);\n",
     "\n",
     "\n",
-    "linreg_pred = linreg_test_fit.extend(\n",
-    "    \"rings_pred\",\n",
-    "    linreg_pred_func(\n",
-    "        linreg_test_fit[\"serialized_linreg_model\"],\n",
-    "        linreg_test_fit[\"length\"],\n",
-    "        linreg_test_fit[\"shucked_weight\"],\n",
-    "    ),\n",
+    "linreg_pred = linreg_test_fit.assign(\n",
+    "    rings_pred=lambda t:\n",
+    "        linreg_pred_func(\n",
+    "            t[\"serialized_linreg_model\"],\n",
+    "            t[\"length\"],\n",
+    "            t[\"shucked_weight\"],\n",
+    "        ),\n",
     ")[[\"id\", \"sex\", \"rings\", \"rings_pred\"]]"
    ]
   },
@@ -926,63 +680,13 @@
    "cell_type": "code",
    "execution_count": 18,
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "collapsed": false
    },
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<table>\n",
-       "\t<tr>\n",
-       "\t\t<th>id</th>\n",
-       "\t\t<th>sex</th>\n",
-       "\t\t<th>rings</th>\n",
-       "\t\t<th>rings_pred</th>\n",
-       "\t</tr>\n",
-       "\t<tr>\n",
-       "\t\t<td>22</td>\n",
-       "\t\t<td>I</td>\n",
-       "\t\t<td>10</td>\n",
-       "\t\t<td>7.064758911925222</td>\n",
-       "\t</tr>\n",
-       "\t<tr>\n",
-       "\t\t<td>44</td>\n",
-       "\t\t<td>I</td>\n",
-       "\t\t<td>5</td>\n",
-       "\t\t<td>4.3352320566205345</td>\n",
-       "\t</tr>\n",
-       "\t<tr>\n",
-       "\t\t<td>59</td>\n",
-       "\t\t<td>I</td>\n",
-       "\t\t<td>4</td>\n",
-       "\t\t<td>4.961196001011494</td>\n",
-       "\t</tr>\n",
-       "\t<tr>\n",
-       "\t\t<td>125</td>\n",
-       "\t\t<td>I</td>\n",
-       "\t\t<td>6</td>\n",
-       "\t\t<td>6.756517856365971</td>\n",
-       "\t</tr>\n",
-       "\t<tr>\n",
-       "\t\t<td>128</td>\n",
-       "\t\t<td>I</td>\n",
-       "\t\t<td>8</td>\n",
-       "\t\t<td>7.158348317600807</td>\n",
-       "\t</tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "| id         || sex        || rings      || rings_pred |\n",
-       "========================================================\n",
-       "|         22 || I          ||         10 || 7.064758911925223 |\n",
-       "|         44 || I          ||          5 || 4.335232056620535 |\n",
-       "|         59 || I          ||          4 || 4.961196001011495 |\n",
-       "|        125 || I          ||          6 || 6.756517856365971 |\n",
-       "|        128 || I          ||          8 || 7.158348317600807 |"
-      ]
+      "text/plain": "| id  || sex || rings || rings_pred        |\n============================================\n|  17 || I   ||     7 || 6.754129634126037 |\n| 125 || I   ||     6 || 6.827778197072346 |\n| 207 || I   ||     9 || 7.472214661390469 |\n| 218 || I   ||     7 || 7.558294015504999 |\n| 239 || I   ||     3 || 2.838131925170855 |",
+      "text/html": "<table>\n\t<tr>\n\t\t<th>id</th>\n\t\t<th>sex</th>\n\t\t<th>rings</th>\n\t\t<th>rings_pred</th>\n\t</tr>\n\t<tr>\n\t\t<td>17</td>\n\t\t<td>I</td>\n\t\t<td>7</td>\n\t\t<td>6.754129634126037</td>\n\t</tr>\n\t<tr>\n\t\t<td>125</td>\n\t\t<td>I</td>\n\t\t<td>6</td>\n\t\t<td>6.827778197072346</td>\n\t</tr>\n\t<tr>\n\t\t<td>207</td>\n\t\t<td>I</td>\n\t\t<td>9</td>\n\t\t<td>7.472214661390469</td>\n\t</tr>\n\t<tr>\n\t\t<td>218</td>\n\t\t<td>I</td>\n\t\t<td>7</td>\n\t\t<td>7.558294015504999</td>\n\t</tr>\n\t<tr>\n\t\t<td>239</td>\n\t\t<td>I</td>\n\t\t<td>3</td>\n\t\t<td>2.838131925170855</td>\n\t</tr>\n</table>"
      },
      "execution_count": 18,
      "metadata": {},
@@ -992,7 +696,7 @@
    "source": [
     "# SELECT * FROM plc_linreg_pred WHERE sex='I' ORDER BY id LIMIT 5;\n",
     "\n",
-    "linreg_pred[linreg_pred[\"sex\"] == \"I\"].order_by(\"id\").head(5)"
+    "linreg_pred[lambda t: t[\"sex\"] == \"I\"].order_by(\"id\")[:5]"
    ]
   },
   {
@@ -1091,53 +795,13 @@
    "cell_type": "code",
    "execution_count": 21,
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "collapsed": false
    },
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<table>\n",
-       "\t<tr>\n",
-       "\t\t<th>mae</th>\n",
-       "\t\t<th>mape</th>\n",
-       "\t\t<th>mse</th>\n",
-       "\t\t<th>r2_score</th>\n",
-       "\t\t<th>sex</th>\n",
-       "\t</tr>\n",
-       "\t<tr>\n",
-       "\t\t<td>2.19173015676694</td>\n",
-       "\t\t<td>19.328471523164783</td>\n",
-       "\t\t<td>9.093740806504178</td>\n",
-       "\t\t<td>0.106803748432587</td>\n",
-       "\t\t<td>F</td>\n",
-       "\t</tr>\n",
-       "\t<tr>\n",
-       "\t\t<td>1.8486465599963873</td>\n",
-       "\t\t<td>18.20059877583045</td>\n",
-       "\t\t<td>5.7465674411093834</td>\n",
-       "\t\t<td>0.16199750988433637</td>\n",
-       "\t\t<td>M</td>\n",
-       "\t</tr>\n",
-       "\t<tr>\n",
-       "\t\t<td>1.3057635589413563</td>\n",
-       "\t\t<td>15.473786026729583</td>\n",
-       "\t\t<td>3.6832514047601204</td>\n",
-       "\t\t<td>0.4418210407385168</td>\n",
-       "\t\t<td>I</td>\n",
-       "\t</tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "| mae        || mape       || mse        || r2_score   || sex        |\n",
-       "======================================================================\n",
-       "| 2.191730156766939 || 19.32847152316477 || 9.09374080650418 || 0.10680374843258666 || F          |\n",
-       "| 1.8486465599963873 || 18.20059877583045 || 5.746567441109382 || 0.1619975098843366 || M          |\n",
-       "| 1.3057635589413563 || 15.47378602672959 || 3.683251404760121 || 0.4418210407385168 || I          |"
-      ]
+      "text/plain": "| sex || mae                || mape               || mse               || r2_score            |\n===============================================================================================\n| F   || 2.0868368325676445 || 19.584275938820824 || 7.755307839731478 || 0.12785963432149094 |\n| M   ||  1.884133793845095 || 18.410957473576868 ||  5.87798266930526 || 0.23079500955503418 |\n| I   || 1.2316096728486696 || 14.993231373352438 || 3.122741462311343 ||  0.4928045669214014 |",
+      "text/html": "<table>\n\t<tr>\n\t\t<th>sex</th>\n\t\t<th>mae</th>\n\t\t<th>mape</th>\n\t\t<th>mse</th>\n\t\t<th>r2_score</th>\n\t</tr>\n\t<tr>\n\t\t<td>F</td>\n\t\t<td>2.0868368325676445</td>\n\t\t<td>19.584275938820824</td>\n\t\t<td>7.755307839731478</td>\n\t\t<td>0.12785963432149094</td>\n\t</tr>\n\t<tr>\n\t\t<td>M</td>\n\t\t<td>1.884133793845095</td>\n\t\t<td>18.410957473576868</td>\n\t\t<td>5.87798266930526</td>\n\t\t<td>0.23079500955503418</td>\n\t</tr>\n\t<tr>\n\t\t<td>I</td>\n\t\t<td>1.2316096728486696</td>\n\t\t<td>14.993231373352438</td>\n\t\t<td>3.122741462311343</td>\n\t\t<td>0.4928045669214014</td>\n\t</tr>\n</table>"
      },
      "execution_count": 21,
      "metadata": {},
@@ -1158,8 +822,17 @@
     "# ) a\n",
     "\n",
     "\n",
-    "linreg_pred.group_by(\"sex\").apply(lambda t: linreg_eval(t[\"rings\"], t[\"rings_pred\"])).to_table()"
+    "linreg_pred.group_by(\"sex\").apply(lambda t: linreg_eval(t[\"rings\"], t[\"rings_pred\"]), expand=True)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "outputs": [],
+   "source": [],
+   "metadata": {
+    "collapsed": false
+   }
   }
  ],
  "metadata": {

--- a/doc/source/notebooks/basic.ipynb
+++ b/doc/source/notebooks/basic.ipynb
@@ -1,999 +1,473 @@
 {
-    "cells": [
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "### Selecting the Database of Your Data\n",
-                "\n",
-                "To begin with, we need to select the database that contains the data we want:"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 1,
-            "metadata": {
-                "pycharm": {
-                    "name": "#%%\n"
-                }
-            },
-            "outputs": [],
-            "source": [
-                "import greenplumpython as gp\n",
-                "\n",
-                "db = gp.database(host=\"localhost\", dbname=\"gpadmin\")"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "### Accessing a Table in the Database\n",
-                "\n",
-                "After selecting the database, we can access a table in the database by specifying its name:"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 2,
-            "metadata": {
-                "pycharm": {
-                    "name": "#%%\n"
-                }
-            },
-            "outputs": [
-                {
-                    "data": {
-                        "text/html": [
-                            "<table>\n",
-                            "\t<tr>\n",
-                            "\t\t<th>i</th>\n",
-                            "\t\t<th>j</th>\n",
-                            "\t\t<th>k</th>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>6</td>\n",
-                            "\t\t<td>6</td>\n",
-                            "\t\t<td>6</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>9</td>\n",
-                            "\t\t<td>9</td>\n",
-                            "\t\t<td>9</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>1</td>\n",
-                            "\t\t<td>1</td>\n",
-                            "\t\t<td>1</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>2</td>\n",
-                            "\t\t<td>2</td>\n",
-                            "\t\t<td>2</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>3</td>\n",
-                            "\t\t<td>3</td>\n",
-                            "\t\t<td>3</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>7</td>\n",
-                            "\t\t<td>7</td>\n",
-                            "\t\t<td>7</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>4</td>\n",
-                            "\t\t<td>4</td>\n",
-                            "\t\t<td>4</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>5</td>\n",
-                            "\t\t<td>5</td>\n",
-                            "\t\t<td>5</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>8</td>\n",
-                            "\t\t<td>8</td>\n",
-                            "\t\t<td>8</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>10</td>\n",
-                            "\t\t<td>10</td>\n",
-                            "\t\t<td>10</td>\n",
-                            "\t</tr>\n",
-                            "</table>"
-                        ],
-                        "text/plain": [
-                            "| i          || j          || k          |\n",
-                            "==========================================\n",
-                            "|          1 ||          1 ||          1 |\n",
-                            "|          2 ||          2 ||          2 |\n",
-                            "|          3 ||          3 ||          3 |\n",
-                            "|          7 ||          7 ||          7 |\n",
-                            "|          6 ||          6 ||          6 |\n",
-                            "|          9 ||          9 ||          9 |\n",
-                            "|          4 ||          4 ||          4 |\n",
-                            "|          5 ||          5 ||          5 |\n",
-                            "|          8 ||          8 ||          8 |\n",
-                            "|         10 ||         10 ||         10 |"
-                        ]
-                    },
-                    "execution_count": 2,
-                    "metadata": {},
-                    "output_type": "execute_result"
-                }
-            ],
-            "source": [
-                "t = gp.table(\"demo\", db=db)\n",
-                "t"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "And of course, we can `SELECT` the first ordered N rows of a table, like this:"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 3,
-            "metadata": {
-                "pycharm": {
-                    "name": "#%%\n"
-                }
-            },
-            "outputs": [
-                {
-                    "data": {
-                        "text/html": [
-                            "<table>\n",
-                            "\t<tr>\n",
-                            "\t\t<th>i</th>\n",
-                            "\t\t<th>j</th>\n",
-                            "\t\t<th>k</th>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>1</td>\n",
-                            "\t\t<td>1</td>\n",
-                            "\t\t<td>1</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>2</td>\n",
-                            "\t\t<td>2</td>\n",
-                            "\t\t<td>2</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>3</td>\n",
-                            "\t\t<td>3</td>\n",
-                            "\t\t<td>3</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>4</td>\n",
-                            "\t\t<td>4</td>\n",
-                            "\t\t<td>4</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>5</td>\n",
-                            "\t\t<td>5</td>\n",
-                            "\t\t<td>5</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>6</td>\n",
-                            "\t\t<td>6</td>\n",
-                            "\t\t<td>6</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>7</td>\n",
-                            "\t\t<td>7</td>\n",
-                            "\t\t<td>7</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>8</td>\n",
-                            "\t\t<td>8</td>\n",
-                            "\t\t<td>8</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>9</td>\n",
-                            "\t\t<td>9</td>\n",
-                            "\t\t<td>9</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>10</td>\n",
-                            "\t\t<td>10</td>\n",
-                            "\t\t<td>10</td>\n",
-                            "\t</tr>\n",
-                            "</table>"
-                        ],
-                        "text/plain": [
-                            "| i          || j          || k          |\n",
-                            "==========================================\n",
-                            "|          1 ||          1 ||          1 |\n",
-                            "|          2 ||          2 ||          2 |\n",
-                            "|          3 ||          3 ||          3 |\n",
-                            "|          4 ||          4 ||          4 |\n",
-                            "|          5 ||          5 ||          5 |\n",
-                            "|          6 ||          6 ||          6 |\n",
-                            "|          7 ||          7 ||          7 |\n",
-                            "|          8 ||          8 ||          8 |\n",
-                            "|          9 ||          9 ||          9 |\n",
-                            "|         10 ||         10 ||         10 |"
-                        ]
-                    },
-                    "execution_count": 3,
-                    "metadata": {},
-                    "output_type": "execute_result"
-                }
-            ],
-            "source": [
-                "t.order_by(t[\"i\"]).head(10)"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "### Basic Data Manipulation\n",
-                "\n",
-                "Now we have a table. We can do basic data manipulation on it, just like in SQL.\n",
-                "\n",
-                "For example, we can `SELECT` a subset of its columns:"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 4,
-            "metadata": {
-                "pycharm": {
-                    "name": "#%%\n"
-                }
-            },
-            "outputs": [
-                {
-                    "data": {
-                        "text/html": [
-                            "<table>\n",
-                            "\t<tr>\n",
-                            "\t\t<th>i</th>\n",
-                            "\t\t<th>j</th>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>6</td>\n",
-                            "\t\t<td>6</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>9</td>\n",
-                            "\t\t<td>9</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>1</td>\n",
-                            "\t\t<td>1</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>2</td>\n",
-                            "\t\t<td>2</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>3</td>\n",
-                            "\t\t<td>3</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>7</td>\n",
-                            "\t\t<td>7</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>4</td>\n",
-                            "\t\t<td>4</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>5</td>\n",
-                            "\t\t<td>5</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>8</td>\n",
-                            "\t\t<td>8</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>10</td>\n",
-                            "\t\t<td>10</td>\n",
-                            "\t</tr>\n",
-                            "</table>"
-                        ],
-                        "text/plain": [
-                            "| i          || j          |\n",
-                            "============================\n",
-                            "|          6 ||          6 |\n",
-                            "|          9 ||          9 |\n",
-                            "|          1 ||          1 |\n",
-                            "|          2 ||          2 |\n",
-                            "|          3 ||          3 |\n",
-                            "|          7 ||          7 |\n",
-                            "|          4 ||          4 |\n",
-                            "|          5 ||          5 |\n",
-                            "|          8 ||          8 |\n",
-                            "|         10 ||         10 |"
-                        ]
-                    },
-                    "execution_count": 4,
-                    "metadata": {},
-                    "output_type": "execute_result"
-                }
-            ],
-            "source": [
-                "t_ij = t[[\"i\", \"j\"]]\n",
-                "t_ij"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "And we can also `SELECT` a subset of its rows. Say we want all the even numbers:"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 5,
-            "metadata": {
-                "pycharm": {
-                    "name": "#%%\n"
-                }
-            },
-            "outputs": [
-                {
-                    "data": {
-                        "text/html": [
-                            "<table>\n",
-                            "\t<tr>\n",
-                            "\t\t<th>i</th>\n",
-                            "\t\t<th>j</th>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>6</td>\n",
-                            "\t\t<td>6</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>2</td>\n",
-                            "\t\t<td>2</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>4</td>\n",
-                            "\t\t<td>4</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>8</td>\n",
-                            "\t\t<td>8</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>10</td>\n",
-                            "\t\t<td>10</td>\n",
-                            "\t</tr>\n",
-                            "</table>"
-                        ],
-                        "text/plain": [
-                            "| i          || j          |\n",
-                            "============================\n",
-                            "|          2 ||          2 |\n",
-                            "|          4 ||          4 |\n",
-                            "|          8 ||          8 |\n",
-                            "|         10 ||         10 |\n",
-                            "|          6 ||          6 |"
-                        ]
-                    },
-                    "execution_count": 5,
-                    "metadata": {},
-                    "output_type": "execute_result"
-                }
-            ],
-            "source": [
-                "t_even = t_ij[t_ij[\"i\"] % 2 == 0]\n",
-                "t_even"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "For a quick glance, we can `SELECT` the first unordered N rows of a table, like this:"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 6,
-            "metadata": {
-                "pycharm": {
-                    "name": "#%%\n"
-                }
-            },
-            "outputs": [
-                {
-                    "data": {
-                        "text/html": [
-                            "<table>\n",
-                            "\t<tr>\n",
-                            "\t\t<th>i</th>\n",
-                            "\t\t<th>j</th>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>6</td>\n",
-                            "\t\t<td>6</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>4</td>\n",
-                            "\t\t<td>4</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>8</td>\n",
-                            "\t\t<td>8</td>\n",
-                            "\t</tr>\n",
-                            "</table>"
-                        ],
-                        "text/plain": [
-                            "| i          || j          |\n",
-                            "============================\n",
-                            "|          6 ||          6 |\n",
-                            "|          2 ||          2 |\n",
-                            "|          4 ||          4 |"
-                        ]
-                    },
-                    "execution_count": 6,
-                    "metadata": {},
-                    "output_type": "execute_result"
-                }
-            ],
-            "source": [
-                "t_n = t_even[:3]\n",
-                "t_n"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "Finally when we are done, we can save the resulting table to the database, either temporarily or persistently:"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 7,
-            "metadata": {
-                "pycharm": {
-                    "name": "#%%\n"
-                }
-            },
-            "outputs": [
-                {
-                    "data": {
-                        "text/html": [
-                            "<table>\n",
-                            "\t<tr>\n",
-                            "\t\t<th>i</th>\n",
-                            "\t\t<th>j</th>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>4</td>\n",
-                            "\t\t<td>4</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>8</td>\n",
-                            "\t\t<td>8</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>10</td>\n",
-                            "\t\t<td>10</td>\n",
-                            "\t</tr>\n",
-                            "</table>"
-                        ],
-                        "text/plain": [
-                            "| i          || j          |\n",
-                            "============================\n",
-                            "|         10 ||         10 |\n",
-                            "|          4 ||          4 |\n",
-                            "|          8 ||          8 |"
-                        ]
-                    },
-                    "execution_count": 7,
-                    "metadata": {},
-                    "output_type": "execute_result"
-                }
-            ],
-            "source": [
-                "t_n.save_as(table_name=\"t_n\", temp=True)"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {
-                "pycharm": {
-                    "name": "#%% md\n"
-                }
-            },
-            "source": [
-                "### `JOIN`-ing Two Tables\n",
-                "\n",
-                "We can also `JOIN` two tables with GreenplumPython. For example, suppose we have two tables like this:"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 8,
-            "metadata": {
-                "pycharm": {
-                    "name": "#%%\n"
-                }
-            },
-            "outputs": [
-                {
-                    "data": {
-                        "text/html": [
-                            "<table>\n",
-                            "\t<tr>\n",
-                            "\t\t<th>id</th>\n",
-                            "\t\t<th>val</th>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>1</td>\n",
-                            "\t\t<td>'a'</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>2</td>\n",
-                            "\t\t<td>'b'</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>3</td>\n",
-                            "\t\t<td>'c'</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>4</td>\n",
-                            "\t\t<td>'d'</td>\n",
-                            "\t</tr>\n",
-                            "</table>"
-                        ],
-                        "text/plain": [
-                            "| id         || val        |\n",
-                            "============================\n",
-                            "|          1 || 'a'        |\n",
-                            "|          2 || 'b'        |\n",
-                            "|          3 || 'c'        |\n",
-                            "|          4 || 'd'        |"
-                        ]
-                    },
-                    "execution_count": 8,
-                    "metadata": {},
-                    "output_type": "execute_result"
-                }
-            ],
-            "source": [
-                "rows = [\n",
-                "    (\n",
-                "        1,\n",
-                "        \"'a'\",\n",
-                "    ),\n",
-                "    (\n",
-                "        2,\n",
-                "        \"'b'\",\n",
-                "    ),\n",
-                "    (\n",
-                "        3,\n",
-                "        \"'c'\",\n",
-                "    ),\n",
-                "    (4, \"'d'\"),\n",
-                "]\n",
-                "t1 = gp.to_table(rows, db=db, column_names=[\"id, val\"])\n",
-                "t1"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 9,
-            "metadata": {
-                "pycharm": {
-                    "name": "#%%\n"
-                }
-            },
-            "outputs": [
-                {
-                    "data": {
-                        "text/html": [
-                            "<table>\n",
-                            "\t<tr>\n",
-                            "\t\t<th>id</th>\n",
-                            "\t\t<th>val</th>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>1</td>\n",
-                            "\t\t<td>'a'</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>2</td>\n",
-                            "\t\t<td>'b'</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>3</td>\n",
-                            "\t\t<td>'a'</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>4</td>\n",
-                            "\t\t<td>'b'</td>\n",
-                            "\t</tr>\n",
-                            "</table>"
-                        ],
-                        "text/plain": [
-                            "| id         || val        |\n",
-                            "============================\n",
-                            "|          1 || 'a'        |\n",
-                            "|          2 || 'b'        |\n",
-                            "|          3 || 'a'        |\n",
-                            "|          4 || 'b'        |"
-                        ]
-                    },
-                    "execution_count": 9,
-                    "metadata": {},
-                    "output_type": "execute_result"
-                }
-            ],
-            "source": [
-                "rows = [\n",
-                "    (\n",
-                "        1,\n",
-                "        \"'a'\",\n",
-                "    ),\n",
-                "    (\n",
-                "        2,\n",
-                "        \"'b'\",\n",
-                "    ),\n",
-                "    (\n",
-                "        3,\n",
-                "        \"'a'\",\n",
-                "    ),\n",
-                "    (4, \"'b'\"),\n",
-                "]\n",
-                "t2 = gp.to_table(rows, db=db, column_names=[\"id, val\"])\n",
-                "t2"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {
-                "pycharm": {
-                    "name": "#%% md\n"
-                }
-            },
-            "source": [
-                "We can `JOIN` the two table like this:"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 10,
-            "metadata": {
-                "pycharm": {
-                    "name": "#%%\n"
-                }
-            },
-            "outputs": [
-                {
-                    "data": {
-                        "text/html": [
-                            "<table>\n",
-                            "\t<tr>\n",
-                            "\t\t<th>t1_id</th>\n",
-                            "\t\t<th>t1_val</th>\n",
-                            "\t\t<th>t2_id</th>\n",
-                            "\t\t<th>t2_val</th>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>1</td>\n",
-                            "\t\t<td>'a'</td>\n",
-                            "\t\t<td>3</td>\n",
-                            "\t\t<td>'a'</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>1</td>\n",
-                            "\t\t<td>'a'</td>\n",
-                            "\t\t<td>1</td>\n",
-                            "\t\t<td>'a'</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>2</td>\n",
-                            "\t\t<td>'b'</td>\n",
-                            "\t\t<td>4</td>\n",
-                            "\t\t<td>'b'</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>2</td>\n",
-                            "\t\t<td>'b'</td>\n",
-                            "\t\t<td>2</td>\n",
-                            "\t\t<td>'b'</td>\n",
-                            "\t</tr>\n",
-                            "</table>"
-                        ],
-                        "text/plain": [
-                            "| t1_id      || t1_val     || t2_id      || t2_val     |\n",
-                            "========================================================\n",
-                            "|          1 || 'a'        ||          3 || 'a'        |\n",
-                            "|          1 || 'a'        ||          1 || 'a'        |\n",
-                            "|          2 || 'b'        ||          4 || 'b'        |\n",
-                            "|          2 || 'b'        ||          2 || 'b'        |"
-                        ]
-                    },
-                    "execution_count": 10,
-                    "metadata": {},
-                    "output_type": "execute_result"
-                }
-            ],
-            "source": [
-                "t_join = t1.join(\n",
-                "    t2,\n",
-                "    cond=t1[\"val\"] == t2[\"val\"],\n",
-                "    self_columns = {\n",
-                "        \"id\": \"t1_id\",\n",
-                "        \"val\": \"t1_val\"\n",
-                "    },\n",
-                "    other_columns = {\n",
-                "        \"id\": \"t2_id\",\n",
-                "        \"val\": \"t2_val\"\n",
-                "    }\n",
-                ")\n",
-                "t_join"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {
-                "pycharm": {
-                    "name": "#%% md\n"
-                }
-            },
-            "source": [
-                "### Creating and Calling Functions\n",
-                "\n",
-                "Calling functions is essential for data analytics. GreenplumPython supports creating Greenplum UDFs and UDAs from Python functions and calling them in Python.\n",
-                "\n",
-                "Suppose we have a table of numbers:"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 11,
-            "metadata": {
-                "pycharm": {
-                    "name": "#%%\n"
-                }
-            },
-            "outputs": [
-                {
-                    "data": {
-                        "text/html": [
-                            "<table>\n",
-                            "\t<tr>\n",
-                            "\t\t<th>val</th>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>0</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>1</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>2</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>3</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>4</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>5</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>6</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>7</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>8</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>9</td>\n",
-                            "\t</tr>\n",
-                            "</table>"
-                        ],
-                        "text/plain": [
-                            "| val        |\n",
-                            "==============\n",
-                            "|          0 |\n",
-                            "|          1 |\n",
-                            "|          2 |\n",
-                            "|          3 |\n",
-                            "|          4 |\n",
-                            "|          5 |\n",
-                            "|          6 |\n",
-                            "|          7 |\n",
-                            "|          8 |\n",
-                            "|          9 |"
-                        ]
-                    },
-                    "execution_count": 11,
-                    "metadata": {},
-                    "output_type": "execute_result"
-                }
-            ],
-            "source": [
-                "rows = [(i,) for i in range(10)]\n",
-                "numbers = gp.to_table(rows, db=db, column_names=[\"val\"])\n",
-                "numbers"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {
-                "pycharm": {
-                    "name": "#%% md\n"
-                }
-            },
-            "source": [
-                "If we want to get the square of each number, we can write a function to do that:"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 12,
-            "metadata": {
-                "pycharm": {
-                    "name": "#%%\n"
-                }
-            },
-            "outputs": [
-                {
-                    "data": {
-                        "text/html": [
-                            "<table>\n",
-                            "\t<tr>\n",
-                            "\t\t<th>result</th>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>0</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>1</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>4</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>9</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>16</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>25</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>36</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>49</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>64</td>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>81</td>\n",
-                            "\t</tr>\n",
-                            "</table>"
-                        ],
-                        "text/plain": [
-                            "| result     |\n",
-                            "==============\n",
-                            "|          0 |\n",
-                            "|          1 |\n",
-                            "|          4 |\n",
-                            "|          9 |\n",
-                            "|         16 |\n",
-                            "|         25 |\n",
-                            "|         36 |\n",
-                            "|         49 |\n",
-                            "|         64 |\n",
-                            "|         81 |"
-                        ]
-                    },
-                    "execution_count": 12,
-                    "metadata": {},
-                    "output_type": "execute_result"
-                }
-            ],
-            "source": [
-                "@gp.create_function\n",
-                "def square(a: int) -> int:\n",
-                "    return a**2\n",
-                "\n",
-                "\n",
-                "square(numbers[\"val\"], as_name=\"result\", db=db).to_table()"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {
-                "pycharm": {
-                    "name": "#%% md\n"
-                }
-            },
-            "source": [
-                "Note that this function is called in exactly the same way as ordinary Python functions.\n",
-                "\n",
-                "If we also want to get the sum of these numbers, what we need is to write an aggregate function like this:"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 13,
-            "metadata": {
-                "pycharm": {
-                    "name": "#%%\n"
-                }
-            },
-            "outputs": [
-                {
-                    "data": {
-                        "text/html": [
-                            "<table>\n",
-                            "\t<tr>\n",
-                            "\t\t<th>result</th>\n",
-                            "\t</tr>\n",
-                            "\t<tr>\n",
-                            "\t\t<td>45</td>\n",
-                            "\t</tr>\n",
-                            "</table>"
-                        ],
-                        "text/plain": [
-                            "| result     |\n",
-                            "==============\n",
-                            "|         45 |"
-                        ]
-                    },
-                    "execution_count": 13,
-                    "metadata": {},
-                    "output_type": "execute_result"
-                }
-            ],
-            "source": [
-                "@gp.create_aggregate\n",
-                "def my_sum(result: int, val: int) -> int:\n",
-                "    if result is None:\n",
-                "        return val\n",
-                "    return result + val\n",
-                "\n",
-                "\n",
-                "my_sum(numbers[\"val\"], as_name=\"result\", db=db).to_table()"
-            ]
-        }
-    ],
-    "metadata": {
-        "jupytext": {
-            "formats": "ipynb,md"
-        },
-        "kernelspec": {
-            "display_name": "Python 3 (ipykernel)",
-            "language": "python",
-            "name": "python3"
-        },
-        "language_info": {
-            "codemirror_mode": {
-                "name": "ipython",
-                "version": 3
-            },
-            "file_extension": ".py",
-            "mimetype": "text/x-python",
-            "name": "python",
-            "nbconvert_exporter": "python",
-            "pygments_lexer": "ipython3",
-            "version": "3.9.5"
-        }
-    },
-    "nbformat": 4,
-    "nbformat_minor": 1
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Selecting the Database of Your Data\n",
+    "\n",
+    "To begin with, we need to select the database that contains the data we want:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import greenplumpython as gp\n",
+    "\n",
+    "db = gp.database(host=\"localhost\", dbname=\"postgres\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Accessing a Table in the Database\n",
+    "\n",
+    "After selecting the database, we can access a table in the database by specifying its name:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "| i || j || k |\n===============\n| 0 || 0 || 0 |\n| 1 || 1 || 1 |\n| 2 || 2 || 2 |\n| 3 || 3 || 3 |\n| 4 || 4 || 4 |\n| 7 || 7 || 7 |\n| 8 || 8 || 8 |\n| 5 || 5 || 5 |\n| 6 || 6 || 6 |\n| 9 || 9 || 9 |",
+      "text/html": "<table>\n\t<tr>\n\t\t<th>i</th>\n\t\t<th>j</th>\n\t\t<th>k</th>\n\t</tr>\n\t<tr>\n\t\t<td>0</td>\n\t\t<td>0</td>\n\t\t<td>0</td>\n\t</tr>\n\t<tr>\n\t\t<td>1</td>\n\t\t<td>1</td>\n\t\t<td>1</td>\n\t</tr>\n\t<tr>\n\t\t<td>2</td>\n\t\t<td>2</td>\n\t\t<td>2</td>\n\t</tr>\n\t<tr>\n\t\t<td>3</td>\n\t\t<td>3</td>\n\t\t<td>3</td>\n\t</tr>\n\t<tr>\n\t\t<td>4</td>\n\t\t<td>4</td>\n\t\t<td>4</td>\n\t</tr>\n\t<tr>\n\t\t<td>7</td>\n\t\t<td>7</td>\n\t\t<td>7</td>\n\t</tr>\n\t<tr>\n\t\t<td>8</td>\n\t\t<td>8</td>\n\t\t<td>8</td>\n\t</tr>\n\t<tr>\n\t\t<td>5</td>\n\t\t<td>5</td>\n\t\t<td>5</td>\n\t</tr>\n\t<tr>\n\t\t<td>6</td>\n\t\t<td>6</td>\n\t\t<td>6</td>\n\t</tr>\n\t<tr>\n\t\t<td>9</td>\n\t\t<td>9</td>\n\t\t<td>9</td>\n\t</tr>\n</table>"
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "t = db.table(\"demo\")\n",
+    "t"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And of course, we can `SELECT` the first ordered N rows of a table, like this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "| i || j || k |\n===============\n| 0 || 0 || 0 |\n| 1 || 1 || 1 |\n| 2 || 2 || 2 |\n| 3 || 3 || 3 |\n| 4 || 4 || 4 |\n| 5 || 5 || 5 |\n| 6 || 6 || 6 |\n| 7 || 7 || 7 |\n| 8 || 8 || 8 |\n| 9 || 9 || 9 |",
+      "text/html": "<table>\n\t<tr>\n\t\t<th>i</th>\n\t\t<th>j</th>\n\t\t<th>k</th>\n\t</tr>\n\t<tr>\n\t\t<td>0</td>\n\t\t<td>0</td>\n\t\t<td>0</td>\n\t</tr>\n\t<tr>\n\t\t<td>1</td>\n\t\t<td>1</td>\n\t\t<td>1</td>\n\t</tr>\n\t<tr>\n\t\t<td>2</td>\n\t\t<td>2</td>\n\t\t<td>2</td>\n\t</tr>\n\t<tr>\n\t\t<td>3</td>\n\t\t<td>3</td>\n\t\t<td>3</td>\n\t</tr>\n\t<tr>\n\t\t<td>4</td>\n\t\t<td>4</td>\n\t\t<td>4</td>\n\t</tr>\n\t<tr>\n\t\t<td>5</td>\n\t\t<td>5</td>\n\t\t<td>5</td>\n\t</tr>\n\t<tr>\n\t\t<td>6</td>\n\t\t<td>6</td>\n\t\t<td>6</td>\n\t</tr>\n\t<tr>\n\t\t<td>7</td>\n\t\t<td>7</td>\n\t\t<td>7</td>\n\t</tr>\n\t<tr>\n\t\t<td>8</td>\n\t\t<td>8</td>\n\t\t<td>8</td>\n\t</tr>\n\t<tr>\n\t\t<td>9</td>\n\t\t<td>9</td>\n\t\t<td>9</td>\n\t</tr>\n</table>"
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "t.order_by(\"i\")[:10]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Basic Data Manipulation\n",
+    "\n",
+    "Now we have a table. We can do basic data manipulation on it, just like in SQL.\n",
+    "\n",
+    "For example, we can `SELECT` a subset of its columns:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "| i || j |\n==========\n| 0 || 0 |\n| 1 || 1 |\n| 2 || 2 |\n| 3 || 3 |\n| 4 || 4 |\n| 7 || 7 |\n| 8 || 8 |\n| 5 || 5 |\n| 6 || 6 |\n| 9 || 9 |",
+      "text/html": "<table>\n\t<tr>\n\t\t<th>i</th>\n\t\t<th>j</th>\n\t</tr>\n\t<tr>\n\t\t<td>0</td>\n\t\t<td>0</td>\n\t</tr>\n\t<tr>\n\t\t<td>1</td>\n\t\t<td>1</td>\n\t</tr>\n\t<tr>\n\t\t<td>2</td>\n\t\t<td>2</td>\n\t</tr>\n\t<tr>\n\t\t<td>3</td>\n\t\t<td>3</td>\n\t</tr>\n\t<tr>\n\t\t<td>4</td>\n\t\t<td>4</td>\n\t</tr>\n\t<tr>\n\t\t<td>7</td>\n\t\t<td>7</td>\n\t</tr>\n\t<tr>\n\t\t<td>8</td>\n\t\t<td>8</td>\n\t</tr>\n\t<tr>\n\t\t<td>5</td>\n\t\t<td>5</td>\n\t</tr>\n\t<tr>\n\t\t<td>6</td>\n\t\t<td>6</td>\n\t</tr>\n\t<tr>\n\t\t<td>9</td>\n\t\t<td>9</td>\n\t</tr>\n</table>"
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "t_ij = t[[\"i\", \"j\"]]\n",
+    "t_ij"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And we can also `SELECT` a subset of its rows. Say we want all the even numbers:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "| i || j |\n==========\n| 0 || 0 |\n| 2 || 2 |\n| 4 || 4 |\n| 8 || 8 |\n| 6 || 6 |",
+      "text/html": "<table>\n\t<tr>\n\t\t<th>i</th>\n\t\t<th>j</th>\n\t</tr>\n\t<tr>\n\t\t<td>0</td>\n\t\t<td>0</td>\n\t</tr>\n\t<tr>\n\t\t<td>2</td>\n\t\t<td>2</td>\n\t</tr>\n\t<tr>\n\t\t<td>4</td>\n\t\t<td>4</td>\n\t</tr>\n\t<tr>\n\t\t<td>8</td>\n\t\t<td>8</td>\n\t</tr>\n\t<tr>\n\t\t<td>6</td>\n\t\t<td>6</td>\n\t</tr>\n</table>"
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "t_even = t_ij[lambda t: t[\"i\"] % 2 == 0]\n",
+    "t_even"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For a quick glance, we can `SELECT` the first unordered N rows of a table, like this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "| i || j |\n==========\n| 0 || 0 |\n| 2 || 2 |\n| 4 || 4 |",
+      "text/html": "<table>\n\t<tr>\n\t\t<th>i</th>\n\t\t<th>j</th>\n\t</tr>\n\t<tr>\n\t\t<td>0</td>\n\t\t<td>0</td>\n\t</tr>\n\t<tr>\n\t\t<td>2</td>\n\t\t<td>2</td>\n\t</tr>\n\t<tr>\n\t\t<td>4</td>\n\t\t<td>4</td>\n\t</tr>\n</table>"
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "t_n = t_even[:3]\n",
+    "t_n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally when we are done, we can save the resulting table to the database, either temporarily or persistently:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "| i || j |\n==========\n| 2 || 2 |\n| 4 || 4 |\n| 8 || 8 |",
+      "text/html": "<table>\n\t<tr>\n\t\t<th>i</th>\n\t\t<th>j</th>\n\t</tr>\n\t<tr>\n\t\t<td>2</td>\n\t\t<td>2</td>\n\t</tr>\n\t<tr>\n\t\t<td>4</td>\n\t\t<td>4</td>\n\t</tr>\n\t<tr>\n\t\t<td>8</td>\n\t\t<td>8</td>\n\t</tr>\n</table>"
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "t_n.save_as(table_name=\"t_n\", temp=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "### `JOIN`-ing Two Tables\n",
+    "\n",
+    "We can also `JOIN` two tables with GreenplumPython. For example, suppose we have two tables like this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "| id || val |\n=============\n|  1 || 'a' |\n|  2 || 'b' |\n|  3 || 'c' |\n|  4 || 'd' |",
+      "text/html": "<table>\n\t<tr>\n\t\t<th>id</th>\n\t\t<th>val</th>\n\t</tr>\n\t<tr>\n\t\t<td>1</td>\n\t\t<td>'a'</td>\n\t</tr>\n\t<tr>\n\t\t<td>2</td>\n\t\t<td>'b'</td>\n\t</tr>\n\t<tr>\n\t\t<td>3</td>\n\t\t<td>'c'</td>\n\t</tr>\n\t<tr>\n\t\t<td>4</td>\n\t\t<td>'d'</td>\n\t</tr>\n</table>"
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rows = [\n",
+    "    (\n",
+    "        1,\n",
+    "        \"'a'\",\n",
+    "    ),\n",
+    "    (\n",
+    "        2,\n",
+    "        \"'b'\",\n",
+    "    ),\n",
+    "    (\n",
+    "        3,\n",
+    "        \"'c'\",\n",
+    "    ),\n",
+    "    (4, \"'d'\"),\n",
+    "]\n",
+    "t1 = gp.to_table(rows, db=db, column_names=[\"id, val\"])\n",
+    "t1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "| id || val |\n=============\n|  1 || 'a' |\n|  2 || 'b' |\n|  3 || 'a' |\n|  4 || 'b' |",
+      "text/html": "<table>\n\t<tr>\n\t\t<th>id</th>\n\t\t<th>val</th>\n\t</tr>\n\t<tr>\n\t\t<td>1</td>\n\t\t<td>'a'</td>\n\t</tr>\n\t<tr>\n\t\t<td>2</td>\n\t\t<td>'b'</td>\n\t</tr>\n\t<tr>\n\t\t<td>3</td>\n\t\t<td>'a'</td>\n\t</tr>\n\t<tr>\n\t\t<td>4</td>\n\t\t<td>'b'</td>\n\t</tr>\n</table>"
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rows = [\n",
+    "    (\n",
+    "        1,\n",
+    "        \"'a'\",\n",
+    "    ),\n",
+    "    (\n",
+    "        2,\n",
+    "        \"'b'\",\n",
+    "    ),\n",
+    "    (\n",
+    "        3,\n",
+    "        \"'a'\",\n",
+    "    ),\n",
+    "    (4, \"'b'\"),\n",
+    "]\n",
+    "t2 = gp.to_table(rows, db=db, column_names=[\"id, val\"])\n",
+    "t2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "We can `JOIN` the two table like this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "| t1_id || t1_val || t2_id || t2_val |\n======================================\n|     1 || 'a'    ||     3 || 'a'    |\n|     1 || 'a'    ||     1 || 'a'    |\n|     2 || 'b'    ||     4 || 'b'    |\n|     2 || 'b'    ||     2 || 'b'    |",
+      "text/html": "<table>\n\t<tr>\n\t\t<th>t1_id</th>\n\t\t<th>t1_val</th>\n\t\t<th>t2_id</th>\n\t\t<th>t2_val</th>\n\t</tr>\n\t<tr>\n\t\t<td>1</td>\n\t\t<td>'a'</td>\n\t\t<td>3</td>\n\t\t<td>'a'</td>\n\t</tr>\n\t<tr>\n\t\t<td>1</td>\n\t\t<td>'a'</td>\n\t\t<td>1</td>\n\t\t<td>'a'</td>\n\t</tr>\n\t<tr>\n\t\t<td>2</td>\n\t\t<td>'b'</td>\n\t\t<td>4</td>\n\t\t<td>'b'</td>\n\t</tr>\n\t<tr>\n\t\t<td>2</td>\n\t\t<td>'b'</td>\n\t\t<td>2</td>\n\t\t<td>'b'</td>\n\t</tr>\n</table>"
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "t_join = t1.join(\n",
+    "    t2,\n",
+    "    using=[\"val\"],\n",
+    "    self_columns = {\n",
+    "        \"id\": \"t1_id\",\n",
+    "        \"val\": \"t1_val\"\n",
+    "    },\n",
+    "    other_columns = {\n",
+    "        \"id\": \"t2_id\",\n",
+    "        \"val\": \"t2_val\"\n",
+    "    }\n",
+    ")\n",
+    "t_join"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "### Creating and Calling Functions\n",
+    "\n",
+    "Calling functions is essential for data analytics. GreenplumPython supports creating Greenplum UDFs and UDAs from Python functions and calling them in Python.\n",
+    "\n",
+    "Suppose we have a table of numbers:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "| val |\n=======\n|   0 |\n|   1 |\n|   2 |\n|   3 |\n|   4 |\n|   5 |\n|   6 |\n|   7 |\n|   8 |\n|   9 |",
+      "text/html": "<table>\n\t<tr>\n\t\t<th>val</th>\n\t</tr>\n\t<tr>\n\t\t<td>0</td>\n\t</tr>\n\t<tr>\n\t\t<td>1</td>\n\t</tr>\n\t<tr>\n\t\t<td>2</td>\n\t</tr>\n\t<tr>\n\t\t<td>3</td>\n\t</tr>\n\t<tr>\n\t\t<td>4</td>\n\t</tr>\n\t<tr>\n\t\t<td>5</td>\n\t</tr>\n\t<tr>\n\t\t<td>6</td>\n\t</tr>\n\t<tr>\n\t\t<td>7</td>\n\t</tr>\n\t<tr>\n\t\t<td>8</td>\n\t</tr>\n\t<tr>\n\t\t<td>9</td>\n\t</tr>\n</table>"
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rows = [(i,) for i in range(10)]\n",
+    "numbers = gp.to_table(rows, db=db, column_names=[\"val\"])\n",
+    "numbers"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "If we want to get the square of each number, we can write a function to do that:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "| square |\n==========\n|      0 |\n|      1 |\n|      4 |\n|      9 |\n|     16 |\n|     25 |\n|     36 |\n|     49 |\n|     64 |\n|     81 |",
+      "text/html": "<table>\n\t<tr>\n\t\t<th>square</th>\n\t</tr>\n\t<tr>\n\t\t<td>0</td>\n\t</tr>\n\t<tr>\n\t\t<td>1</td>\n\t</tr>\n\t<tr>\n\t\t<td>4</td>\n\t</tr>\n\t<tr>\n\t\t<td>9</td>\n\t</tr>\n\t<tr>\n\t\t<td>16</td>\n\t</tr>\n\t<tr>\n\t\t<td>25</td>\n\t</tr>\n\t<tr>\n\t\t<td>36</td>\n\t</tr>\n\t<tr>\n\t\t<td>49</td>\n\t</tr>\n\t<tr>\n\t\t<td>64</td>\n\t</tr>\n\t<tr>\n\t\t<td>81</td>\n\t</tr>\n</table>"
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "@gp.create_function\n",
+    "def square(a: int) -> int:\n",
+    "    return a**2\n",
+    "\n",
+    "\n",
+    "numbers.apply(lambda t: square(t[\"val\"]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "Note that this function is called in exactly the same way as ordinary Python functions.\n",
+    "\n",
+    "If we also want to get the sum of these numbers, what we need is to write an aggregate function like this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "| my_sum |\n==========\n|     45 |",
+      "text/html": "<table>\n\t<tr>\n\t\t<th>my_sum</th>\n\t</tr>\n\t<tr>\n\t\t<td>45</td>\n\t</tr>\n</table>"
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "@gp.create_aggregate\n",
+    "def my_sum(result: int, val: int) -> int:\n",
+    "    if result is None:\n",
+    "        return val\n",
+    "    return result + val\n",
+    "\n",
+    "\n",
+    "numbers.apply(lambda t: my_sum(t[\"val\"]))"
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "formats": "ipynb,md"
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/greenplumpython/db.py
+++ b/greenplumpython/db.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional,
 
 if TYPE_CHECKING:
     from greenplumpython.table import Table
+    from greenplumpython.func import FunctionExpr
 
 import psycopg2
 import psycopg2.extras
@@ -84,6 +85,26 @@ class Database:
         from greenplumpython.table import table
 
         return table(name, self)
+
+    def apply(
+        self,
+        func: Callable[[], "FunctionExpr"],
+        expand: bool = False,
+        as_name: Optional[str] = None,
+    ) -> "Table":
+        """
+        Apply a function in database.
+        Args:
+            func: An aggregate function to be applied to
+            expand: bool: expand field of composite returning type
+            as_name: str: rename returning column
+        Returns:
+            Table: resulted Table
+        Example:
+            .. code-block::  python
+                db.apply(lambda row: add(1, 2))
+        """
+        return func().bind(db=self, expand=expand, as_name=as_name).apply()
 
     def assign(self, **new_columns: Callable[[], Any]) -> "Table":
         from greenplumpython.expr import Expr

--- a/greenplumpython/db.py
+++ b/greenplumpython/db.py
@@ -104,7 +104,7 @@ class Database:
             .. code-block::  python
                 db.apply(lambda row: add(1, 2))
         """
-        return func().bind(db=self, expand=expand).apply(as_name=as_name)
+        return func().bind(db=self).apply(expand=expand, as_name=as_name)
 
     def assign(self, **new_columns: Callable[[], Any]) -> "Table":
         from greenplumpython.expr import Expr

--- a/greenplumpython/db.py
+++ b/greenplumpython/db.py
@@ -104,7 +104,7 @@ class Database:
             .. code-block::  python
                 db.apply(lambda row: add(1, 2))
         """
-        return func().bind(db=self, expand=expand, as_name=as_name).apply()
+        return func().bind(db=self, expand=expand).apply(as_name=as_name)
 
     def assign(self, **new_columns: Callable[[], Any]) -> "Table":
         from greenplumpython.expr import Expr

--- a/greenplumpython/group.py
+++ b/greenplumpython/group.py
@@ -48,7 +48,7 @@ class TableGroupingSets:
             .. code-block::  python
                 numbers.group_by("is_even").apply(lambda row: count(row["*"]))
         """
-        return func(self._table).bind(group_by=self, expand=expand).apply(as_name=as_name)
+        return func(self._table).bind(group_by=self).apply(expand=expand, as_name=as_name)
 
     def assign(self, **new_columns: Callable[["Table"], Any]) -> "Table":
         """

--- a/greenplumpython/group.py
+++ b/greenplumpython/group.py
@@ -48,7 +48,7 @@ class TableGroupingSets:
             .. code-block::  python
                 numbers.group_by("is_even").apply(lambda row: count(row["*"]))
         """
-        return func(self._table).bind(group_by=self, expand=expand, as_name=as_name).apply()
+        return func(self._table).bind(group_by=self, expand=expand).apply(as_name=as_name)
 
     def assign(self, **new_columns: Callable[["Table"], Any]) -> "Table":
         """

--- a/greenplumpython/group.py
+++ b/greenplumpython/group.py
@@ -33,15 +33,12 @@ class TableGroupingSets:
         """
         from greenplumpython.table import Table
 
-        if len(new_columns) == 0:
-            return self
-        targets: List[str] = []
+        targets: List[str] = list(self.flatten())
         for k, f in new_columns.items():
             v: Any = f(self.table).bind(group_by=self)
             if isinstance(v, Expr) and not (v.table is None or v.table == self.table):
                 raise Exception("Newly included columns must be based on the current table")
             targets.append(f"{v.serialize() if isinstance(v, Expr) else to_pg_const(v)} AS {k}")
-        targets += list(self.flatten())
         return Table(
             f"SELECT {','.join(targets)} FROM {self.table.name} {self.clause()}",
             parents=[self.table],

--- a/greenplumpython/order.py
+++ b/greenplumpython/order.py
@@ -66,12 +66,12 @@ class OrderedTable:
         )
 
     # FIXME : Not sure about return type
-    def head(self, num: int) -> "Table":
+    def __getitem__(self, rows: slice) -> "Table":
         """
-        Returns a :class:`~table.Table` that contains the first **num** rows in order.
+        Returns a :class:`~table.Table` that contains the slice of table in order.
 
         Args:
-            num: int: number of first rows
+            rows: slice: number of first rows
 
         Returns:
             Table: Ordered by table
@@ -83,12 +83,16 @@ class OrderedTable:
         """
         from greenplumpython.table import Table
 
+        if rows.step is not None:
+            raise NotImplementedError()
+        offset_clause = "" if rows.start is None else f"OFFSET {rows.start}"
+        limit_clause = (
+            ""
+            if rows.stop is None
+            else f"LIMIT {rows.stop if rows.start is None else rows.stop - rows.start}"
+        )
         return Table(
-            f"""
-                SELECT * FROM {self._table.name}
-                {self._clause()}
-                LIMIT {num}
-            """,
+            f"SELECT * FROM {self._table.name} {self._clause()} {limit_clause} {offset_clause}",
             parents=[self._table],
         )
 

--- a/greenplumpython/row.py
+++ b/greenplumpython/row.py
@@ -24,6 +24,9 @@ class Row:
     def __iter__(self):
         return iter(self._contents)
 
+    def __len__(self):
+        return len(self._contents)
+
     def column_names(self) -> List[str]:
         """
         Return list of column names of row

--- a/greenplumpython/table.py
+++ b/greenplumpython/table.py
@@ -632,6 +632,20 @@ class Table:
         #    |------------------------- to_table() ---------------|
         return TableGroupingSets(self, [column_names])
 
+    def distinct_on(self, *column_names: str) -> "Table":
+        """
+        Deduplicate the current :class:`Table` with respect to the given columns.
+
+        Args:
+            column_names: name of column of the current :class:`Table`.
+
+        Returns:
+            :class:`Table`: Table containing only the distinct values of the
+                            given columns.
+        """
+        cols = [Column(name, self).serialize() for name in column_names]
+        return Table(f"SELECT DISTINCT ON ({','.join(cols)}) * FROM {self.name}", parents=[self])
+
 
 # table_name can be table/view name
 def table(name: str, db: db.Database) -> Table:

--- a/greenplumpython/table.py
+++ b/greenplumpython/table.py
@@ -281,7 +281,7 @@ class Table:
         #
         # To fix this, we need to pass the table to the resulting FunctionExpr
         # explicitly.
-        return func(self).bind(table=self, expand=expand, as_name=as_name).apply()
+        return func(self).bind(table=self, expand=expand).apply(as_name=as_name)
 
     def assign(self, **new_columns: Callable[["Table"], Any]) -> "Table":
         """

--- a/greenplumpython/table.py
+++ b/greenplumpython/table.py
@@ -281,7 +281,7 @@ class Table:
         #
         # To fix this, we need to pass the table to the resulting FunctionExpr
         # explicitly.
-        return func(self).bind(table=self, expand=expand).apply(as_name=as_name)
+        return func(self).bind(table=self).apply(expand=expand, as_name=as_name)
 
     def assign(self, **new_columns: Callable[["Table"], Any]) -> "Table":
         """

--- a/tests/test_builtin.py
+++ b/tests/test_builtin.py
@@ -5,7 +5,18 @@ import greenplumpython.builtin.function as F
 from tests import db
 
 
-def test_builtin_func_call(db: gp.Database):
+def test_builtin_func_assign(db: gp.Database):
+    rows = [(i,) for i in range(10)]
+    result = (
+        gp.to_table(rows, db=db, column_names=["a"])
+        .group_by()
+        .assign(count=lambda t: F.count(t["a"]))
+    )
+    assert len(list(result)) == 1
+    assert next(iter(result))["count"] == 10
+
+
+def test_builtin_func_assign_stop_iteration(db: gp.Database):
     rows = [(i,) for i in range(10)]
     t = gp.to_table(rows, db=db, column_names=["a"])
     result = t.group_by().assign(count=lambda t: F.count(t["a"]))
@@ -17,21 +28,17 @@ def test_builtin_func_call(db: gp.Database):
     assert str(exc_info.value) == "StopIteration: Reached last row of table!"
 
 
-def test_builtin_func_apply(db: gp.Database):
-    rows = [(i,) for i in range(10)]
-    result = (
-        gp.to_table(rows, db=db, column_names=["a"])
-        .group_by()
-        .assign(count=lambda t: F.count(t["a"]))
-    )
-    assert len(list(result)) == 1
-    assert next(iter(result))["count"] == 10
-
-
 def test_builtin_func_no_arg(db: gp.Database):
     rows = [(i,) for i in range(10)]
     result = (
         gp.to_table(rows, db=db, column_names=["a"]).group_by().assign(count=lambda _: F.count())
     )
+    assert len(list(result)) == 1
+    assert next(iter(result))["count"] == 10
+
+
+def test_builtin_func_apply(db: gp.Database):
+    rows = [(i,) for i in range(10)]
+    result = gp.to_table(rows, db=db, column_names=["a"]).apply(lambda _: F.count())
     assert len(list(result)) == 1
     assert next(iter(result))["count"] == 10

--- a/tests/test_const_table.py
+++ b/tests/test_const_table.py
@@ -66,7 +66,7 @@ def test_table_display_repr(db: gp.Database):
         "|  3 || Wolf   |\n"
         "|  4 || Fox    |\n"
     )
-    assert str(t.order_by("id").head(4)) == expected
+    assert str(t.order_by("id")[:]) == expected
 
 
 def test_table_display_repr_long_content(db: gp.Database):
@@ -82,7 +82,7 @@ def test_table_display_repr_long_content(db: gp.Database):
         "|                    3 || Wolf             |\n"
         "|                    4 || Fox              |\n"
     )
-    assert str(t.order_by("iddddddddddddddddddd").head(4)) == expected
+    assert str(t.order_by("iddddddddddddddddddd")[:]) == expected
 
 
 def test_table_display_repr_html(db: gp.Database):
@@ -114,7 +114,7 @@ def test_table_display_repr_html(db: gp.Database):
         "\t</tr>\n"
         "</table>"
     )
-    assert (t.order_by("id").head(4)._repr_html_()) == expected
+    assert (t.order_by("id")[:]._repr_html_()) == expected
 
 
 def test_table_display_repr_empty_result(db: gp.Database):

--- a/tests/test_const_table.py
+++ b/tests/test_const_table.py
@@ -245,3 +245,18 @@ def test_table_refresh_add_columns(db: gp.Database):
     t.refresh()
     for row in t:
         assert row["num_copy"] is not None and row["num_copy"] == row["num"]
+
+
+def test_table_distinct(db: gp.Database):
+    rows = [(i, 1) for i in range(10)]
+    t = gp.to_table(rows, db=db, column_names=["i", "j"])
+
+    result = list(t.distinct_on("i", "j"))
+    assert len(result) == len(rows)
+    for row in result:
+        assert "i" in row and "j" in row
+
+    result = list(t.distinct_on("j"))
+    assert len(result) == 1
+    for row in result:
+        assert "i" in row and "j" in row

--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -31,9 +31,15 @@ def test_create_func(db: gp.Database):
     def add(a: int, b: int) -> int:
         return a + b
 
+    # -- WITH ASSIGN FUNC
     for row in db.assign(result=lambda: add(1, 2)):
         assert row["result"] == 1 + 2
         assert row["result"] == add.unwrap()(1, 2)
+
+    # -- WITH APPLY FUNC
+    for row in db.apply(lambda: add(1, 2)):
+        assert row["add"] == 1 + 2
+        assert row["add"] == add.unwrap()(1, 2)
 
 
 def test_create_func_multiline(db: gp.Database):
@@ -44,9 +50,15 @@ def test_create_func_multiline(db: gp.Database):
         else:
             return b
 
+    # -- WITH ASSIGN FUNC
     for row in db.assign(result=lambda: my_max(1, 2)):
         assert row["result"] == max(1, 2)
         assert row["result"] == my_max.unwrap()(1, 2)
+
+    # -- WITH APPLY FUNC
+    for row in db.apply(lambda: my_max(1, 2)):
+        assert row["my_max"] == max(1, 2)
+        assert row["my_max"] == my_max.unwrap()(1, 2)
 
 
 # fmt: off
@@ -68,8 +80,14 @@ def test_func_on_one_column(db: gp.Database):
     rows = [(i,) for i in range(-10, 0)]
     series = gp.to_table(rows, db=db, column_names=["id"])
     abs = gp.function("abs")
+
+    # -- WITH ASSIGN FUNC
     results = series.assign(abs=lambda nums: abs(nums["id"]))
     assert sorted([row["abs"] for row in results]) == list(range(1, 11))
+
+    # -- WITH APPLY FUNC
+    results2 = series.apply(lambda nums: abs(nums["id"]))
+    assert sorted([row["abs"] for row in results2]) == list(range(1, 11))
 
 
 def test_func_on_multi_columns(db: gp.Database, series: gp.Table):
@@ -77,7 +95,12 @@ def test_func_on_multi_columns(db: gp.Database, series: gp.Table):
     def multiply(a: int, b: int) -> int:
         return a * b
 
+    # -- WITH ASSIGN FUNC
     results = series.assign(result=lambda t: multiply(t["a"], t["b"]))
+    assert sorted([row["result"] for row in results]) == [i * i for i in range(10)]
+
+    # -- WITH APPLY FUNC
+    results = series.apply(lambda t: multiply(t["a"], t["b"]), as_name="result")
     assert sorted([row["result"] for row in results]) == [i * i for i in range(10)]
 
 
@@ -97,7 +120,12 @@ def test_simple_agg(db: gp.Database):
     numbers = gp.to_table(rows, db=db, column_names=["val"])
     count = gp.aggregate_function("count")
 
+    # -- WITH ASSIGN FUNC
     results = numbers.group_by().assign(count=lambda t: count(t["val"]))
+    assert len(list(results)) == 1 and next(iter(results))["count"] == 10
+
+    # -- WITH APPLY FUNC
+    results = numbers.apply(lambda t: count(t["val"]))
     assert len(list(results)) == 1 and next(iter(results))["count"] == 10
 
 
@@ -106,9 +134,14 @@ def test_agg_group_by(db: gp.Database):
     numbers = gp.to_table(rows, db=db, column_names=["val", "is_even"])
     count = gp.aggregate_function("count")
 
-    # FIXME: Remove extraneous rename() in group_by() after spearating Expr
-    # with NamedExpr.
+    # -- WITH ASSIGN FUNC
     results = numbers.group_by("is_even").assign(count=lambda t: count(t["val"]))
+    for row in results:
+        assert ("is_even" in row) and (row["is_even"] is not None) and (row["count"] == 5)
+    assert len(list(results)) == 2
+
+    # -- WITH APPLY FUNC
+    results = numbers.group_by("is_even").apply(lambda t: count(t["val"]))
     for row in results:
         assert ("is_even" in row) and (row["is_even"] is not None) and (row["count"] == 5)
     assert len(list(results)) == 2
@@ -119,9 +152,27 @@ def test_agg_group_by_multi_columns(db: gp.Database):
     numbers = gp.to_table(rows, db=db, column_names=["val", "is_even", "is_multiple_of_3"])
     count = gp.aggregate_function("count")
 
+    # -- WITH ASSIGN FUNC
     results = numbers.group_by("is_even", "is_multiple_of_3").assign(
         count=lambda t: count(t["val"])
     )
+    assert len(list(results)) == 4  # 2 attributes * 2 possible values per attribute
+    for row in results:
+        assert (
+            ("is_even" in row)
+            and (row["is_even"] is not None)
+            and ("is_multiple_of_3" in row)
+            and (row["is_multiple_of_3"] is not None)
+        )
+        assert (
+            (row["is_even"] and row["is_multiple_of_3"] and row["count"] == 1)  # 0
+            or (row["is_even"] and not row["is_multiple_of_3"] and row["count"] == 2)  # 2, 4
+            or (not row["is_even"] and row["is_multiple_of_3"] and row["count"] == 1)  # 3
+            or (not row["is_even"] and not row["is_multiple_of_3"] and row["count"] == 2)  # 1, 5
+        )
+
+    # -- WITH APPLY FUNC
+    results = numbers.group_by("is_even", "is_multiple_of_3").apply(lambda t: count(t["val"]))
     assert len(list(results)) == 4  # 2 attributes * 2 possible values per attribute
     for row in results:
         assert (
@@ -148,8 +199,14 @@ def my_sum(result: int, val: int) -> int:
 def test_create_agg(db: gp.Database):
     rows = [(1,) for _ in range(10)]
     numbers = gp.to_table(rows, db=db, column_names=["val"])
+
+    # -- WITH ASSIGN FUNC
     results = numbers.group_by().assign(result=lambda t: my_sum(t["val"]))
     assert len(list(results)) == 1 and next(iter(results))["result"] == 10
+
+    # -- WITH APPLY FUNC
+    results = numbers.group_by().apply(lambda t: my_sum(t["val"]))
+    assert len(list(results)) == 1 and next(iter(results))["my_sum"] == 10
 
 
 def test_create_agg_multi_args(db: gp.Database):
@@ -161,7 +218,15 @@ def test_create_agg_multi_args(db: gp.Database):
 
     rows = [(1, 2) for _ in range(10)]
     vectors = gp.to_table(rows, db=db, column_names=["a", "b"])
+
+    # -- WITH ASSIGN FUNC
     results = vectors.group_by().assign(result=lambda t: manhattan_distance(t["a"], t["b"]))
+    assert len(list(results)) == 1 and next(iter(results))["result"] == 10
+
+    # -- WITH APPLY FUNC
+    results = vectors.group_by().apply(
+        lambda t: manhattan_distance(t["a"], t["b"]), as_name="result"
+    )
     assert len(list(results)) == 1 and next(iter(results))["result"] == 10
 
 
@@ -204,20 +269,35 @@ def my_sum_array(val_list: List[int]) -> int:
 def test_array_func(db: gp.Database):
     rows = [(1,) for _ in range(10)]
     numbers = gp.to_table(rows, db=db, column_names=["val"])
+
+    # -- WITH ASSIGN FUNC
     results = numbers.group_by().assign(result=lambda t: my_sum_array(t["val"]))
+    assert len(list(results)) == 1 and next(iter(results))["result"] == 10
+
+    # -- WITH APPLY FUNC
+    results = numbers.group_by().apply(lambda t: my_sum_array(t["val"]), as_name="result")
     assert len(list(results)) == 1 and next(iter(results))["result"] == 10
 
 
 def test_array_func_group_by(db: gp.Database):
     rows = [(1, i % 2 == 0) for i in range(10)]
     numbers = gp.to_table(rows, db=db, column_names=["val", "is_even"])
-    results = numbers.group_by("is_even").assign(result=lambda t: my_sum_array(t["val"]))
 
+    # -- WITH ASSIGN FUNC
+    results = numbers.group_by("is_even").assign(result=lambda t: my_sum_array(t["val"]))
     assert len(list(results)) == 2
     assert all(e in next(iter(results)).column_names() for e in ["result", "is_even"])
     for row in results:
         print(row["is_even"])
         assert ("is_even" in row) and (row["is_even"] is not None) and (row["result"] == 5)
+
+    # -- WITH APPLY FUNC
+    results = numbers.group_by("is_even").apply(lambda t: my_sum_array(t["val"]), as_name="my_sum")
+    assert len(list(results)) == 2
+    assert all(e in next(iter(results)).column_names() for e in ["my_sum", "is_even"])
+    for row in results:
+        print(row["is_even"])
+        assert ("is_even" in row) and (row["is_even"] is not None) and (row["my_sum"] == 5)
 
 
 def test_array_func_group_by_return_composite(db: gp.Database):
@@ -233,6 +313,8 @@ def test_array_func_group_by_return_composite(db: gp.Database):
     rows = [(1, "a",), (1, "a",), (1, "b",), (1, "a",), (1, "b",), (1, "b",)]
     # fmt: on
     numbers = gp.to_table(rows, db=db, column_names=["val", "lab"])
+
+    # -- WITH ASSIGN FUNC
     ret = (
         numbers.group_by("lab")
         .assign(result=lambda t: my_count_sum(t["val"]))
@@ -240,6 +322,14 @@ def test_array_func_group_by_return_composite(db: gp.Database):
     )
     assert all(e in next(iter(ret)).column_names() for e in ["_sum", "_count", "lab"])
     for row in ret:
+        assert row["_sum"] == 3
+        assert row["_count"] == 3
+
+    # -- WITH APPLY FUNC
+    ret_apply = numbers.group_by("lab").apply(lambda t: my_count_sum(t["val"]), expand=True)
+    print(next(iter(ret_apply)).column_names())
+    assert all(e in next(iter(ret_apply)).column_names() for e in ["_sum", "_count", "lab"])
+    for row in ret_apply:
         assert row["_sum"] == 3
         assert row["_count"] == 3
 
@@ -251,11 +341,16 @@ def test_array_func_group_by_return_composite(db: gp.Database):
     def create_person(first: str, last: str) -> Person:
         return {"_first_name": first, "_last_name": last}
 
+    # -- WITH ASSIGN FUNC
     for row in db.assign(result=lambda: create_person("Amy", "An")).assign(
         first_name=lambda t: t["result"]["_first_name"],
         last_name=lambda t: t["result"]["_last_name"],
     ):
         assert row["first_name"] == "Amy" and row["last_name"] == "An"
+
+    # -- WITH APPLY FUNC
+    for row in db.apply(lambda: create_person("Amy", "An"), expand=True):
+        assert row["_first_name"] == "Amy" and row["_last_name"] == "An"
 
 
 class Pair:
@@ -271,9 +366,15 @@ def create_pair(num: int) -> Pair:
 def test_func_composite_type_column(db: gp.Database):
     rows = [(i,) for i in range(10)]
     numbers = gp.to_table(rows, db=db, column_names=["val"])
+
+    # -- WITH ASSIGN FUNC
     for row in numbers.assign(result=lambda t: create_pair(t["val"])).assign(
         _next=lambda t: t["result"]["_next"], _num=lambda t: t["result"]["_num"]
     ):
+        assert row["_next"] == row["_num"] + 1
+
+    # -- WITH APPLY FUNC
+    for row in numbers.apply(lambda t: create_pair(t["val"]), expand=True):
         assert row["_next"] == row["_num"] + 1
 
 
@@ -288,12 +389,24 @@ def test_func_composite_type_setof(db: gp.Database):
 
     rows = [(i,) for i in range(10)]
     numbers = gp.to_table(rows, db=db, column_names=["val"])
+
+    # -- WITH ASSIGN FUNC
     ret = numbers.assign(result=lambda t: create_pair_tuple(t["val"])).assign(
         _next=lambda t: t["result"]["_next"], _num=lambda t: t["result"]["_num"]
     )
     assert len(list(ret)) == 50
     dict_record = {i: 0 for i in range(10)}
     for row in ret:
+        dict_record[row["_num"]] += 1
+        assert row["_next"] == row["_num"] + 1
+    for key in dict_record:
+        assert dict_record[key] == 5
+
+    # -- WITH APPLY FUNC
+    ret_apply = numbers.apply(lambda t: create_pair_tuple(t["val"]), expand=True)
+    assert len(list(ret_apply)) == 50
+    dict_record = {i: 0 for i in range(10)}
+    for row in ret_apply:
         dict_record[row["_num"]] += 1
         assert row["_next"] == row["_num"] + 1
     for key in dict_record:
@@ -313,6 +426,8 @@ def my_stat(val_list: List[int]) -> Stat:
 def test_array_func_composite_type(db: gp.Database):
     rows = [(i,) for i in range(10)]
     numbers = gp.to_table(rows, db=db, column_names=["val"])
+
+    # -- WITH ASSIGN FUNC
     ret = (
         numbers.group_by()
         .assign(result=lambda t: my_stat(t["val"]))
@@ -321,12 +436,25 @@ def test_array_func_composite_type(db: gp.Database):
     for row in ret:
         assert row["sum"] == sum(list([i for i in range(10)])) and row["count"] == len(rows)
 
+    # -- WITH APPLY FUNC
+    ret_apply = numbers.group_by().apply(lambda t: my_stat(t["val"]), expand=True)
+    for row in ret_apply:
+        assert row["sum"] == sum(list([i for i in range(10)])) and row["count"] == len(rows)
+
 
 def test_func_apply_single_column(db: gp.Database):
     rows = [(i,) for i in range(-10, 0)]
     series = gp.to_table(rows, db=db, column_names=["id"])
     abs = gp.function("abs")
+
+    # -- WITH ASSIGN FUNC
     result = series.assign(abs=lambda t: abs(t["id"]))
+    assert len(list(result)) == 10
+    for row in result:
+        assert row["abs"] >= 0
+
+    # -- WITH APPLY FUNC
+    result = series.apply(lambda t: abs(t["id"]))
     assert len(list(result)) == 10
     for row in result:
         assert row["abs"] >= 0
@@ -340,7 +468,15 @@ def label(type_or_type: str, num: int) -> str:
 def test_func_apply_const_and_column(db: gp.Database):
     rows = [(i,) for i in range(10)]
     numbers = gp.to_table(rows, db=db, column_names=["val"])
+
+    # -- WITH ASSIGN FUNC
     result = numbers.assign(label=lambda t: label("label", t["val"]))
+    assert len(list(result)) == 10
+    for row in result:
+        assert row["label"].startswith("label")
+
+    # -- WITH APPLY FUNC
+    result = numbers.apply(lambda t: label("label", t["val"]))
     assert len(list(result)) == 10
     for row in result:
         assert row["label"].startswith("label")
@@ -356,7 +492,14 @@ def test_func_apply_join(db: gp.Database):
     ret = t1.join(
         t2, cond=lambda t1, t2: t1["id1"] == t2["id2"], self_columns={"id1"}, other_columns={"n2"}
     )
+
+    # -- WITH ASSIGN FUNC
     result = ret.assign(label=lambda t: label(t["n2"], t["id1"]))
+    for row in result:
+        assert row["label"][1] == row["label"][2]
+
+    # -- WITH APPLY FUNC
+    result = ret.apply(lambda t: label(t["n2"], t["id1"]))
     for row in result:
         assert row["label"][1] == row["label"][2]
 
@@ -364,9 +507,15 @@ def test_func_apply_join(db: gp.Database):
 def test_func_composite_type_column_apply(db: gp.Database):
     rows = [(i,) for i in range(10)]
     numbers = gp.to_table(rows, db=db, column_names=["val"])
+
+    # -- WITH ASSIGN FUNC
     for row in numbers.assign(result=lambda tab: create_pair(tab["val"])).assign(
         _next=lambda t: t["result"]["_next"], _num=lambda t: t["result"]["_num"]
     ):
+        assert row["_next"] == row["_num"] + 1
+
+    # -- WITH APPLY FUNC
+    for row in numbers.apply(lambda tab: create_pair(tab["val"]), expand=True):
         assert row["_next"] == row["_num"] + 1
 
 
@@ -374,18 +523,33 @@ def test_array_func_apply(db: gp.Database):
     rows = [(1,) for _ in range(10)]
     numbers = gp.to_table(rows, db=db, column_names=["val"])
 
+    # -- WITH ASSIGN FUNC
     results = numbers.group_by().assign(my_sum=lambda t: my_sum_array(t["val"]))
     assert len(list(results)) == 1 and next(iter(results))["my_sum"] == 10
+
+    # -- WITH APPLY FUNC
+    results = numbers.group_by().apply(lambda t: my_sum_array(t["val"]))
+    assert len(list(results)) == 1 and next(iter(results))["my_sum_array"] == 10
 
 
 def test_array_func_group_by_composite_apply(db: gp.Database):
     rows = [(1, i % 2 == 0) for i in range(10)]
     numbers = gp.to_table(rows, db=db, column_names=["val", "is_even"])
+
+    # -- WITH ASSIGN FUNC
     results = (
         numbers.group_by("is_even")
         .assign(result=lambda tab: my_stat(tab["val"]))
         .assign(sum=lambda t: t["result"]["sum"], count=lambda t: t["result"]["sum"])
     )
+    assert all(e in next(iter(results)).column_names() for e in ["sum", "count", "is_even"])
+    for row in results:
+        assert all(
+            ["is_even" in row, row["is_even"] is not None, row["sum"] == 5, row["count"] == 5]
+        )
+
+    # -- WITH APPLY FUNC
+    results = numbers.group_by("is_even").apply(lambda tab: my_stat(tab["val"]), expand=True)
     assert all(e in next(iter(results)).column_names() for e in ["sum", "count", "is_even"])
     for row in results:
         assert all(
@@ -402,8 +566,13 @@ def test_array_func_const_apply(db: gp.Database):
     rows = [(1,) for _ in range(10)]
     numbers = gp.to_table(rows, db=db, column_names=["val"])
 
+    # -- WITH ASSIGN FUNC
     results = numbers.group_by().assign(my_sum=lambda tab: my_sum_const("sum", tab["val"], 5))
     assert len(list(results)) == 1 and next(iter(results))["my_sum"] == "sum : 15"
+
+    # -- WITH APPLY FUNC
+    results = numbers.group_by().apply(lambda tab: my_sum_const("sum", tab["val"], 5))
+    assert len(list(results)) == 1 and next(iter(results))["my_sum_const"] == "sum : 15"
 
 
 def test_array_func_group_by_attribute(db: gp.Database):
@@ -411,10 +580,18 @@ def test_array_func_group_by_attribute(db: gp.Database):
     rows = [("a", i, 5,) for i in range(10)]
     # fmt: on
     numbers = gp.to_table(rows, db=db, column_names=["label", "val", "initial"])
+
+    # -- WITH ASSIGN FUNC
     results = numbers.group_by("label", "initial").assign(
         my_sum=lambda tab: my_sum_const(tab["label"], tab["val"], tab["initial"])
     )
     assert len(list(results)) == 1 and next(iter(results))["my_sum"] == "a : 50"
+
+    # -- WITH APPLY FUNC
+    results = numbers.group_by("label", "initial").apply(
+        lambda tab: my_sum_const(tab["label"], tab["val"], tab["initial"])
+    )
+    assert len(list(results)) == 1 and next(iter(results))["my_sum_const"] == "a : 50"
 
 
 def test_func_return_list_composite(db: gp.Database):
@@ -426,9 +603,15 @@ def test_func_return_list_composite(db: gp.Database):
     def add_to_cart(customer: str, items: List[str]) -> ShoppingCart:
         return {"customer": customer, "items": items}
 
+    # -- WITH ASSIGN FUNC
     results = db.assign(result=lambda: add_to_cart("alice", ["apple"])).assign(
         customer=lambda t: t["result"]["customer"], items=lambda t: t["result"]["items"]
     )
+    for row in results:
+        assert row["customer"] == "alice" and row["items"] == ["apple"]
+
+    # -- WITH APPLY FUNC
+    results = db.apply(lambda: add_to_cart("alice", ["apple"]), expand=True)
     for row in results:
         assert row["customer"] == "alice" and row["items"] == ["apple"]
 

--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -639,6 +639,7 @@ def test_agg_returning_table(db: gp.Database):
 
     rows = [(i,) for i in range(10)]
     numbers = gp.to_table(rows, db=db, column_names=["val"])
+    # -- WITH ASSIGN FUNC
     with pytest.raises(Exception):  # state transition functions may not return table
         numbers.group_by().assign(result=lambda t: pass_agg(t["val"]))
 
@@ -648,6 +649,8 @@ def test_agg_distinct(db: gp.Database):
     numbers = gp.to_table(rows, db=db, column_names=["val"])
 
     count = gp.aggregate_function("count")
+
+    # -- WITH ASSIGN FUNC
     result = numbers.group_by().assign(
         count=lambda t: count(t["val"]), count_distinct=lambda t: count.distinct(t["val"])
     )

--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -458,3 +458,15 @@ def test_agg_returning_table(db: gp.Database):
     numbers = gp.to_table(rows, db=db, column_names=["val"])
     with pytest.raises(Exception):  # state transition functions may not return table
         numbers.group_by().assign(result=lambda t: pass_agg(t["val"]))
+
+
+def test_agg_distinct(db: gp.Database):
+    rows = [(1,) for _ in range(10)]
+    numbers = gp.to_table(rows, db=db, column_names=["val"])
+
+    count = gp.aggregate_function("count")
+    result = numbers.group_by().assign(
+        count=lambda t: count(t["val"]), count_distinct=lambda t: count.distinct(t["val"])
+    )
+    for row in result:
+        assert row["count"] == len(rows) and row["count_distinct"] == len(set(rows)) == 1

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -79,3 +79,12 @@ def test_group_union(db: gp.Database):
             or (row["is_even"] is None and row["is_multiple_of_3"] and row["count"] == 2)
             or (row["is_even"] is None and not row["is_multiple_of_3"] and row["count"] == 4)
         )
+
+
+def test_group_empty_assign_empty(db: gp.Database):
+    rows = [(i,) for i in range(10)]
+    t = gp.to_table(rows, db=db, column_names=["i"])
+    results = list(t.group_by().assign())
+    # NOTE: len(results) == 1 on PostgreSQL, while == 10 on Greenplum
+    for row in results:
+        assert len(row) == 0

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -9,7 +9,14 @@ def test_group_agg(db: gp.Database):
     numbers = gp.to_table(rows, db=db, column_names=["val", "is_even"])
     count = gp.aggregate_function("count")
 
+    # -- WITH ASSIGN FUNC
     results = numbers.group_by("is_even").assign(count=lambda row: count(row["*"]))
+    assert len(list(results)) == 2
+    for row in results:
+        assert ("is_even" in row) and (row["is_even"] is not None) and (row["count"] == 5)
+
+    # -- WITH APPLY FUNC
+    results = numbers.group_by("is_even").apply(lambda row: count(row["*"]))
     assert len(list(results)) == 2
     for row in results:
         assert ("is_even" in row) and (row["is_even"] is not None) and (row["count"] == 5)
@@ -25,6 +32,7 @@ def test_group_agg_multi_columns(db: gp.Database):
             return val + val_cp
         return result + val + val_cp
 
+    # -- WITH ASSIGN FUNC
     results = numbers.group_by("is_even").assign(
         my_sum=lambda row: my_sum_copy(row["val"], row["val_cp"])
     )
@@ -35,15 +43,42 @@ def test_group_agg_multi_columns(db: gp.Database):
             (not row["is_even"]) and row["my_sum"] == 2 * sum(list(range(1, 10, 2)))
         )
 
+    # -- WITH APPLY FUNC
+    results = numbers.group_by("is_even").apply(lambda row: my_sum_copy(row["val"], row["val_cp"]))
+    assert len(list(results)) == 2
+    for row in results:
+        assert ("is_even" in row) and (row["is_even"] is not None)
+        assert (row["is_even"] and row["my_sum_copy"] == 2 * sum(list(range(0, 10, 2)))) or (
+            (not row["is_even"]) and row["my_sum_copy"] == 2 * sum(list(range(1, 10, 2)))
+        )
+
 
 def test_group_by_multi_columns(db: gp.Database):
     rows = [(i, i % 2 == 0, i % 3 == 0) for i in range(6)]  # 0, 1, 2, 3, 4, 5
     numbers = gp.to_table(rows, db=db, column_names=["val", "is_even", "is_multiple_of_3"])
     count = gp.aggregate_function("count")
 
+    # -- WITH ASSIGN FUNC
     results = numbers.group_by("is_even", "is_multiple_of_3").assign(
         count=lambda t: count(t["val"])
     )
+    assert len(list(results)) == 4  # 2 attributes * 2 possible values per attribute
+    for row in results:
+        assert (
+            ("is_even" in row)
+            and (row["is_even"] is not None)
+            and ("is_multiple_of_3" in row)
+            and (row["is_multiple_of_3"] is not None)
+        )
+        assert (
+            (row["is_even"] and row["is_multiple_of_3"] and row["count"] == 1)  # 0
+            or (row["is_even"] and not row["is_multiple_of_3"] and row["count"] == 2)  # 2, 4
+            or (not row["is_even"] and row["is_multiple_of_3"] and row["count"] == 1)  # 3
+            or (not row["is_even"] and not row["is_multiple_of_3"] and row["count"] == 2)  # 1, 5
+        )
+
+    # -- WITH APPLY FUNC
+    results = numbers.group_by("is_even", "is_multiple_of_3").apply(lambda t: count(t["val"]))
     assert len(list(results)) == 4  # 2 attributes * 2 possible values per attribute
     for row in results:
         assert (
@@ -65,10 +100,27 @@ def test_group_union(db: gp.Database):
     numbers = gp.to_table(rows, db=db, column_names=["val", "is_even", "is_multiple_of_3"])
     count = gp.aggregate_function("count")
 
+    # -- WITH ASSIGN FUNC
     results = (
         numbers.group_by("is_even")
         .union(lambda t: t.group_by("is_multiple_of_3"))
         .assign(count=lambda t: count(t["val"]))
+    )
+    assert len(list(results)) == 4  # 2 attributes * 2 possible values per attribute
+    for row in results:
+        assert ("is_even" in row) and ("is_multiple_of_3" in row)
+        assert (
+            (row["is_even"] and row["is_multiple_of_3"] is None and row["count"] == 3)
+            or (not row["is_even"] and row["is_multiple_of_3"] is None and row["count"] == 3)
+            or (row["is_even"] is None and row["is_multiple_of_3"] and row["count"] == 2)
+            or (row["is_even"] is None and not row["is_multiple_of_3"] and row["count"] == 4)
+        )
+
+    # -- WITH APPLY FUNC
+    results = (
+        numbers.group_by("is_even")
+        .union(lambda t: t.group_by("is_multiple_of_3"))
+        .apply(lambda t: count(t["val"]))
     )
     assert len(list(results)) == 4  # 2 attributes * 2 possible values per attribute
     for row in results:

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -13,8 +13,8 @@ def t(db: gp.Database):
     return t
 
 
-def test_order_by_head(db: gp.Database, t: gp.Table):
-    ret = t.order_by("id").head(5)
+def test_order_by_slice(db: gp.Database, t: gp.Table):
+    ret = t.order_by("id")[:5]
     assert len(list(ret)) == 5
     assert next(iter(ret))["id"] == 0
     assert next(ret)["id"] == 1
@@ -23,8 +23,13 @@ def test_order_by_head(db: gp.Database, t: gp.Table):
     assert next(ret)["id"] == 4
 
 
-def test_order_by_head_desc(db: gp.Database, t: gp.Table):
-    ret = t.order_by("id", ascending=False).head(5)
+def test_order_by_slice_empty(db: gp.Database, t: gp.Table):
+    ret = t.order_by("id")[:]
+    assert len(list(ret)) == 10
+
+
+def test_order_by_slice_desc(db: gp.Database, t: gp.Table):
+    ret = t.order_by("id", ascending=False)[:5]
     assert len(list(ret)) == 5
     assert next(iter(ret))["id"] == 9
     assert next(ret)["id"] == 8
@@ -33,15 +38,15 @@ def test_order_by_head_desc(db: gp.Database, t: gp.Table):
     assert next(ret)["id"] == 5
 
 
-def test_order_by_head_operator(db: gp.Database, t: gp.Table):
-    ret = t.order_by("id", operator=">").head(3)
+def test_order_by_slice_operator(db: gp.Database, t: gp.Table):
+    ret = t.order_by("id", operator=">")[:3]
     assert len(list(ret)) == 3
     assert next(iter(ret))["id"] == 9
     assert next(ret)["id"] == 8
     assert next(ret)["id"] == 7
 
 
-def test_order_by_head_asc_operator(db: gp.Database, t: gp.Table):
+def test_order_by_slice_asc_operator(db: gp.Database, t: gp.Table):
     with pytest.raises(Exception) as exc_info:
         t.order_by("id", ascending=True, operator="<")
     assert str(exc_info.value).startswith(
@@ -49,12 +54,12 @@ def test_order_by_head_asc_operator(db: gp.Database, t: gp.Table):
     )
 
 
-def test_order_by_multiple_head(db: gp.Database):
+def test_order_by_multiple_slice(db: gp.Database):
     # fmt: off
     rows = [(1, 2,), (1, 3,), (2, 2,), (3, 1,), (3, 4,)]
     # fmt: on
     t = gp.to_table(rows, db=db, column_names=["id", "num"])
-    ret = t.order_by("id").order_by("num", ascending=False).head(5)
+    ret = t.order_by("id").order_by("num", ascending=False)[:5]
     assert len(list(ret)) == 5
     row = next(iter(ret))
     assert row["id"] == 1 and row["num"] == 3
@@ -63,7 +68,7 @@ def test_order_by_multiple_head(db: gp.Database):
     row = next(ret)
     row = next(ret)
     assert row["id"] == 3 and row["num"] == 1
-    ret2 = t.order_by("num", ascending=False).order_by("id").head(5)
+    ret2 = t.order_by("num", ascending=False).order_by("id")[:5]
     assert len(list(ret)) == 5
     row = next(iter(ret2))
     assert row["id"] == 3 and row["num"] == 4
@@ -81,7 +86,7 @@ def test_order_by_nulls_last(db: gp.Database):
             (4, "The Night Watch", 1642,)]
     # fmt: on
     t = gp.to_table(rows, db=db, column_names=["id", "painting", "year"])
-    ret = t.order_by("year", nulls_first=False).head(5)
+    ret = t.order_by("year", nulls_first=False)[:5]
     assert (
         next(iter(ret))["year"] is not None
         and next(ret)["year"] is not None


### PR DESCRIPTION
When applying a function on the table, the user can only select returning columns, 
the `assign()` function keeps all of the columns of the table applied, which could bring
extra work to users. This patch supports `apply()` function which returns a Table
only with returning columns of UDF. 