### PR TITLE
Feat: set up to display sql or not

### DIFF
--- a/doc/source/config.rst
+++ b/doc/source/config.rst
@@ -2,7 +2,10 @@ Configuration
 =============
 .. module:: greenplumpython
 
+This file contains all the variables to configure GreenplumPython, users can directly set them by assigning value.
+
 .. automodule:: config
    :members:
    :show-inheritance:
    :member-order: bysource
+   :noindex: print_sql

--- a/doc/source/config.rst
+++ b/doc/source/config.rst
@@ -2,8 +2,6 @@ Configuration
 =============
 .. module:: greenplumpython
 
-This file contains all the variables to configure GreenplumPython, users can directly set them by assigning value.
-
 .. automodule:: config
    :members:
    :show-inheritance:

--- a/doc/source/config.rst
+++ b/doc/source/config.rst
@@ -1,0 +1,8 @@
+Configuration
+=============
+.. module:: greenplumpython
+
+.. automodule:: config
+   :members:
+   :show-inheritance:
+   :member-order: bysource

--- a/doc/source/config.rst
+++ b/doc/source/config.rst
@@ -1,9 +1,6 @@
 Configuration
 =============
-.. module:: greenplumpython
 
 .. automodule:: config
    :members:
-   :show-inheritance:
    :member-order: bysource
-   :noindex: print_sql

--- a/doc/source/modules.rst
+++ b/doc/source/modules.rst
@@ -16,3 +16,4 @@ The **GreenplumPython** library contains 5 main modules:
    type
    group
    order
+   config

--- a/greenplumpython/__init__.py
+++ b/greenplumpython/__init__.py
@@ -1,4 +1,4 @@
-from greenplumpython.db import Database, database
+from greenplumpython.db import Database, database, options_dict, set_option
 from greenplumpython.expr import Expr
 from greenplumpython.func import create_aggregate  # type: ignore
 from greenplumpython.func import create_array_function  # type: ignore

--- a/greenplumpython/__init__.py
+++ b/greenplumpython/__init__.py
@@ -1,4 +1,5 @@
-from greenplumpython.db import Database, database, options_dict, set_option
+import greenplumpython.config
+from greenplumpython.db import Database, database
 from greenplumpython.expr import Expr
 from greenplumpython.func import create_aggregate  # type: ignore
 from greenplumpython.func import create_array_function  # type: ignore

--- a/greenplumpython/config.py
+++ b/greenplumpython/config.py
@@ -1,4 +1,7 @@
-# This file contains all the variables to configure GreenplumPython, users can directly set them by assigning value.
+"""
+This file contains all the variables to configure GreenplumPython, users can directly set them by assigning value.
+
+"""
 
 print_sql: bool = False
 """

--- a/greenplumpython/config.py
+++ b/greenplumpython/config.py
@@ -1,0 +1,8 @@
+"""
+This file contains all the variables to configure GreenplumPython, users can directly set them by assign value to them.
+"""
+
+print_sql: bool = False
+"""
+This variable configure to display or not the SQL query sent by GreenplumPython to Database behind each command.
+"""

--- a/greenplumpython/config.py
+++ b/greenplumpython/config.py
@@ -4,5 +4,6 @@ This file contains all the variables to configure GreenplumPython, users can dir
 
 print_sql: bool = False
 """
+:noindex:
 This variable configure to display or not the SQL query sent by GreenplumPython to Database behind each command.
 """

--- a/greenplumpython/config.py
+++ b/greenplumpython/config.py
@@ -1,9 +1,6 @@
-"""
-This file contains all the variables to configure GreenplumPython, users can directly set them by assign value to them.
-"""
+# This file contains all the variables to configure GreenplumPython, users can directly set them by assigning value.
 
 print_sql: bool = False
 """
-:noindex:
-This variable configure to display or not the SQL query sent by GreenplumPython to Database behind each command.
+    This variable configure to display or not the SQL query sent by GreenplumPython to Database behind each command.
 """

--- a/greenplumpython/db.py
+++ b/greenplumpython/db.py
@@ -3,7 +3,7 @@ This  module can create a connection to a Greenplum database
 """
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Tuple
 
-import greenplumpython.config
+import greenplumpython.config as gp_config
 
 if TYPE_CHECKING:
     from greenplumpython.table import Table
@@ -45,7 +45,7 @@ class Database:
         """
 
         with self._conn.cursor() as cursor:
-            if greenplumpython.config.print_sql:
+            if gp_config.print_sql:
                 print(query)
             cursor.execute(query)
             return cursor.fetchall() if has_results else None

--- a/greenplumpython/db.py
+++ b/greenplumpython/db.py
@@ -10,6 +10,8 @@ if TYPE_CHECKING:
 import psycopg2
 import psycopg2.extras
 
+options_dict = {"sql_on": False}
+
 
 class Database:
     """
@@ -42,6 +44,8 @@ class Database:
 
         """
         with self._conn.cursor() as cursor:
+            if options_dict["sql_on"]:
+                print(query)
             cursor.execute(query)
             return cursor.fetchall() if has_results else None
 
@@ -189,3 +193,19 @@ def database(
     if password is not None:
         params["password"] = password
     return Database(params)
+
+
+def set_option(option: str, value: Any):
+    """
+    Set option when using GreenplumPython. List of options:
+        sql_on: determine whether to show or not the SQL query executed in database
+
+    Args:
+        option: str: name of the option
+        value: undefined: value to set up
+
+    Returns:
+        void
+    """
+    assert option in options_dict, f'Option named "{option}" not exists.'
+    options_dict[option] = value

--- a/greenplumpython/db.py
+++ b/greenplumpython/db.py
@@ -3,7 +3,7 @@ This  module can create a connection to a Greenplum database
 """
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Tuple
 
-import greenplumpython.config as gp_config
+from greenplumpython import config
 
 if TYPE_CHECKING:
     from greenplumpython.table import Table
@@ -45,7 +45,7 @@ class Database:
         """
 
         with self._conn.cursor() as cursor:
-            if gp_config.print_sql:
+            if config.print_sql:
                 print(query)
             cursor.execute(query)
             return cursor.fetchall() if has_results else None

--- a/greenplumpython/db.py
+++ b/greenplumpython/db.py
@@ -3,7 +3,7 @@ This  module can create a connection to a Greenplum database
 """
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Tuple
 
-import greenplumpython.config as config
+import greenplumpython.config as gp_config
 
 if TYPE_CHECKING:
     from greenplumpython.table import Table
@@ -44,7 +44,7 @@ class Database:
 
         """
         with self._conn.cursor() as cursor:
-            if config.print_sql:
+            if gp_config.print_sql:
                 print(query)
             cursor.execute(query)
             return cursor.fetchall() if has_results else None

--- a/greenplumpython/db.py
+++ b/greenplumpython/db.py
@@ -3,8 +3,6 @@ This  module can create a connection to a Greenplum database
 """
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Tuple
 
-import greenplumpython.config as gp_config
-
 if TYPE_CHECKING:
     from greenplumpython.table import Table
     from greenplumpython.func import FunctionExpr
@@ -43,6 +41,8 @@ class Database:
                 result = db.execute("SELECT version()")
 
         """
+        import greenplumpython.config as gp_config
+
         with self._conn.cursor() as cursor:
             if gp_config.print_sql:
                 print(query)

--- a/greenplumpython/db.py
+++ b/greenplumpython/db.py
@@ -3,6 +3,8 @@ This  module can create a connection to a Greenplum database
 """
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Tuple
 
+import greenplumpython.config
+
 if TYPE_CHECKING:
     from greenplumpython.table import Table
     from greenplumpython.func import FunctionExpr
@@ -41,10 +43,9 @@ class Database:
                 result = db.execute("SELECT version()")
 
         """
-        import greenplumpython.config as gp_config
 
         with self._conn.cursor() as cursor:
-            if gp_config.print_sql:
+            if greenplumpython.config.print_sql:
                 print(query)
             cursor.execute(query)
             return cursor.fetchall() if has_results else None

--- a/greenplumpython/db.py
+++ b/greenplumpython/db.py
@@ -3,14 +3,14 @@ This  module can create a connection to a Greenplum database
 """
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Tuple
 
+import greenplumpython.config as config
+
 if TYPE_CHECKING:
     from greenplumpython.table import Table
     from greenplumpython.func import FunctionExpr
 
 import psycopg2
 import psycopg2.extras
-
-options_dict = {"sql_on": False}
 
 
 class Database:
@@ -44,7 +44,7 @@ class Database:
 
         """
         with self._conn.cursor() as cursor:
-            if options_dict["sql_on"]:
+            if config.print_sql:
                 print(query)
             cursor.execute(query)
             return cursor.fetchall() if has_results else None
@@ -54,21 +54,6 @@ class Database:
         Close the self database connection
         """
         self._conn.close()
-
-    # FIXME: How to get other "global" variables, e.g. CURRENT_ROLE, CURRENT_TIMETAMP, etc.?
-    def set_config(self, key: str, value: Any):
-        """
-        Set Database parameters
-
-        Args:
-            key: str : database parameter name
-            value: undefined : value to set up
-
-        Returns:
-            void
-        """
-        assert isinstance(key, str)
-        self.execute(f"SET {key} TO {value}", has_results=False)
 
     def table(self, name: str):
         """
@@ -193,19 +178,3 @@ def database(
     if password is not None:
         params["password"] = password
     return Database(params)
-
-
-def set_option(option: str, value: Any):
-    """
-    Set option when using GreenplumPython. List of options:
-        sql_on: determine whether to show or not the SQL query executed in database
-
-    Args:
-        option: str: name of the option
-        value: undefined: value to set up
-
-    Returns:
-        void
-    """
-    assert option in options_dict, f'Option named "{option}" not exists.'
-    options_dict[option] = value

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -2,5 +2,5 @@
 sphinx==5.1.1
 sphinx_rtd_theme==1.0.0
 nbsphinx
-ipython
+ipython~=8.6.0
 pandoc

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,5 +1,7 @@
 from os import environ
 
+import pytest
+
 import greenplumpython as gp
 from tests import db
 
@@ -17,8 +19,19 @@ def test_db():
     db.close()
 
 
-def test_dg_get_table(db: gp.Database):
+def test_db_get_table(db: gp.Database):
     rows = [(1,) for _ in range(10)]
     gp.to_table(rows, db=db, column_names=["val"]).save_as("numbers", temp=True)
     numbers = db.table("numbers")
     assert sum(row["val"] for row in numbers) == 10
+
+
+def test_set_option():
+    assert gp.options_dict["sql_on"] is False
+    gp.set_option("sql_on", True)
+    assert gp.options_dict["sql_on"] is True
+    gp.set_option("sql_on", False)
+    assert gp.options_dict["sql_on"] is False
+    with pytest.raises(Exception) as exc_info:
+        gp.set_option("mode", 0)
+    assert str(exc_info.value) == 'Option named "mode" not exists.'

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -26,12 +26,9 @@ def test_db_get_table(db: gp.Database):
     assert sum(row["val"] for row in numbers) == 10
 
 
-def test_set_option():
-    assert gp.options_dict["sql_on"] is False
-    gp.set_option("sql_on", True)
-    assert gp.options_dict["sql_on"] is True
-    gp.set_option("sql_on", False)
-    assert gp.options_dict["sql_on"] is False
-    with pytest.raises(Exception) as exc_info:
-        gp.set_option("mode", 0)
-    assert str(exc_info.value) == 'Option named "mode" not exists.'
+def test_print_sql():
+    assert gp.config.print_sql is False
+    gp.config.print_sql = True
+    assert gp.config.print_sql is True
+    gp.config.print_sql = False
+    assert gp.config.print_sql is False

--- a/tests/test_op.py
+++ b/tests/test_op.py
@@ -25,7 +25,7 @@ def test_op_index(db: gp.Database):
     student = gp.to_table(rows, db=db, column_names=["info"]).save_as("student", temp=True)
     db.execute("CREATE INDEX student_name ON student USING gin (info)", has_results=False)
 
-    db.set_config("enable_seqscan", False)
+    db.execute("SET enable_seqscan TO False", has_results=False)
     json_contains = gp.operator("@>", db)
     results = student[lambda t: json_contains(t["info"], json.dumps({"name": "john"}))].explain()
     uses_index_scan = False

--- a/tox.ini
+++ b/tox.ini
@@ -50,4 +50,5 @@ passenv=
 commands =
     # for doc generate we need to install this moudle that can `import greenplumpython`
     pip install --force-reinstall .
+    pip install --force-reinstall psycopg2-binary
     sphinx-build -W --keep-going -b html -j 2 {toxinidir}/doc/source doc/build/{env:TAG_REF:}

--- a/tox.ini
+++ b/tox.ini
@@ -50,5 +50,6 @@ passenv=
 commands =
     # for doc generate we need to install this moudle that can `import greenplumpython`
     pip install --force-reinstall .
+    # fix problem for macos when building docs in local evironment
     pip install --force-reinstall psycopg2-binary
     sphinx-build -W --keep-going -b html -j 2 {toxinidir}/doc/source doc/build/{env:TAG_REF:}

--- a/tox.ini
+++ b/tox.ini
@@ -50,4 +50,6 @@ passenv=
 commands =
     # for doc generate we need to install this moudle that can `import greenplumpython`
     pip install --force-reinstall .
+    # for MacOS M1 pro to generate doc
+    pip install --force-reinstall psycopg2-binary
     sphinx-build -W --keep-going -b html -j 2 {toxinidir}/doc/source doc/build/{env:TAG_REF:}

--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,4 @@ passenv=
 commands =
     # for doc generate we need to install this moudle that can `import greenplumpython`
     pip install --force-reinstall .
-    # for MacOS M1 pro to generate doc
-    pip install --force-reinstall psycopg2-binary
     sphinx-build -W --keep-going -b html -j 2 {toxinidir}/doc/source doc/build/{env:TAG_REF:}


### PR DESCRIPTION
To understand the result of GreenplumPython, users could
want to investigate the SQL query sent by GreenplumPython
to the database. This patch adds a global method to set up the option "sql_on".
If "sql_on" is True, GreenplumPython will print the query in the output, 
otherwise not. The default value is False.