### PR TITLE
Fix Join default select empty problem

### DIFF
--- a/greenplumpython/table.py
+++ b/greenplumpython/table.py
@@ -477,6 +477,14 @@ class Table:
     Equivalent to calling :meth:`Table.join` with `how="CROSS"`.
     """
 
+    semi_join = partialmethod(join, how="INNER", other_columns={})
+    """
+    Semi joins the current :class:`Table` with another :class:`Table`,
+    returns only columns of self.
+
+    Equivalent to calling :meth:`Table.join` with `other_columns={}`.
+    """
+
     @property
     def name(self) -> str:
         """

--- a/tests/test_binaryExpr.py
+++ b/tests/test_binaryExpr.py
@@ -37,7 +37,7 @@ def test_expr_bin_equal_2expr(db: gp.Database):
     t2 = gp.to_table(rows, db=db).save_as("temp5", temp=True, column_names=["id"])
     b4: Callable[[gp.Table, gp.Table], gp.Expr] = lambda t1, t2: t1["id"] == t2["id"]
     assert str(b4(t1, t2)) == "(temp4.id = temp5.id)"
-    assert len(list(t1.join(t2, using=["id"]))) == 3
+    assert len(list(t1.join(t2, using=["id"], self_columns={"id"}, other_columns={}))) == 3
 
 
 def test_expr_bin_equal_bool(db: gp.Database):

--- a/tests/test_binaryExpr.py
+++ b/tests/test_binaryExpr.py
@@ -37,7 +37,7 @@ def test_expr_bin_equal_2expr(db: gp.Database):
     t2 = gp.to_table(rows, db=db).save_as("temp5", temp=True, column_names=["id"])
     b4: Callable[[gp.Table, gp.Table], gp.Expr] = lambda t1, t2: t1["id"] == t2["id"]
     assert str(b4(t1, t2)) == "(temp4.id = temp5.id)"
-    assert len(list(t1.semi_join(t2, using=["id"]))) == 3
+    assert len(list(t1.join(t2, using=["id"], other_columns={}))) == 3
 
 
 def test_expr_bin_equal_bool(db: gp.Database):

--- a/tests/test_binaryExpr.py
+++ b/tests/test_binaryExpr.py
@@ -37,7 +37,7 @@ def test_expr_bin_equal_2expr(db: gp.Database):
     t2 = gp.to_table(rows, db=db).save_as("temp5", temp=True, column_names=["id"])
     b4: Callable[[gp.Table, gp.Table], gp.Expr] = lambda t1, t2: t1["id"] == t2["id"]
     assert str(b4(t1, t2)) == "(temp4.id = temp5.id)"
-    assert len(list(t1.join(t2, using=["id"], self_columns={"id"}, other_columns={}))) == 3
+    assert len(list(t1.semi_join(t2, using=["id"]))) == 3
 
 
 def test_expr_bin_equal_bool(db: gp.Database):

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -55,7 +55,7 @@ def test_join_all_and_all_columns(db: gp.Database, t1: gp.Table, t2: gp.Table):
 
 def test_join_no_and_no_columns(db: gp.Database, t1: gp.Table, t2: gp.Table):
     ret = next(iter(t1.join(t2, cond=lambda t1, t2: t1["id1"] == t2["id2"])))
-    assert "id1" not in ret and "id2" not in ret  # NOTE: The row is not empty with psycopg2
+    assert "id1" in ret and "id2" in ret
 
 
 def test_join_all_and_no_columns(db: gp.Database, t1: gp.Table, t2: gp.Table):
@@ -233,9 +233,8 @@ def test_table_cross_join(db: gp.Database, zoo_1: gp.Table, zoo_2: gp.Table):
 
 
 def test_table_self_join(db: gp.Database, zoo_1: gp.Table):
-    zoo_2 = zoo_1.rename("zoo2")
     ret: gp.Table = zoo_1.join(
-        zoo_2,
+        zoo_1,
         using=["animal"],
         self_columns={"animal": "zoo1_animal", "id": "zoo1_id"},
         other_columns={"animal": "zoo2_animal", "id": "zoo2_id"},
@@ -246,9 +245,8 @@ def test_table_self_join(db: gp.Database, zoo_1: gp.Table):
 
 
 def test_table_join_save(db: gp.Database, zoo_1: gp.Table):
-    zoo_2 = zoo_1.rename("zoo2")
     t_join: gp.Table = zoo_1.join(
-        zoo_2,
+        zoo_1,
         using=["animal"],
         self_columns={"animal": "zoo1_animal", "id": "zoo1_id"},
         other_columns={"animal": "zoo2_animal", "id": "zoo2_id"},
@@ -275,16 +273,14 @@ def test_table_join_ine(db: gp.Database):
 
 
 def test_table_multiple_self_join(db: gp.Database, zoo_1: gp.Table):
-    zoo_2 = zoo_1.rename("zoo2")
-    zoo_3 = zoo_2.rename("zoo3")
     t_join = zoo_1.join(
-        zoo_2,
+        zoo_1,
         using=["animal"],
         self_columns={"animal": "zoo1_animal", "id": "zoo1_id"},
         other_columns={"animal": "zoo2_animal", "id": "zoo2_id"},
     )
     ret = t_join.join(
-        zoo_3,
+        zoo_1,
         cond=lambda s, o: s["zoo1_animal"] == o["animal"],
         self_columns={"*"},
         other_columns={"*"},
@@ -304,5 +300,5 @@ def test_lineage_dfs_order(db: gp.Database):
     numbers = gp.to_table(rows, db=db, column_names=["val"])
     mod = numbers.assign(mod=lambda t: t["val"] % 2)
     mod3 = mod.assign(mod3=lambda t: t["val"] % 3)
-    results: gp.Table = mod3.join(numbers, using=["val"], self_columns={"val"})
+    results: gp.Table = mod3.join(numbers, using=["val"], self_columns={"val"}, other_columns={})
     assert len(list(results)) == 10

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -49,18 +49,23 @@ def test_join_all_and_all_columns(db: gp.Database, t1: gp.Table, t2: gp.Table):
             )
         )
     )
-    for col in ["id1", "idd1", "n1", "id2", "idd2", "n2"]:
-        assert col in row
+    assert sorted(row.column_names()) == sorted(["id1", "idd1", "n1", "id2", "idd2", "n2"])
 
 
 def test_join_no_and_no_columns(db: gp.Database, t1: gp.Table, t2: gp.Table):
     ret = next(iter(t1.join(t2, cond=lambda t1, t2: t1["id1"] == t2["id2"])))
-    assert ret.column_names() == ['id1', 'idd1', 'n1', 'id2', 'idd2', 'n2']
+    assert sorted(ret.column_names()) == sorted(["id1", "idd1", "n1", "id2", "idd2", "n2"])
 
 
 def test_join_all_and_no_columns(db: gp.Database, t1: gp.Table, t2: gp.Table):
-    ret = next(iter(t1.join(t2, cond=lambda t1, t2: t1["id1"] == t2["id2"], self_columns={}, other_columns={"*"})))
-    assert ret.column_names() == ["id2", "idd2", "n2"]
+    ret = next(
+        iter(
+            t1.join(
+                t2, cond=lambda t1, t2: t1["id1"] == t2["id2"], self_columns={}, other_columns={"*"}
+            )
+        )
+    )
+    assert sorted(ret.column_names()) == sorted(["id2", "idd2", "n2"])
 
 
 def test_join_all_and_one_columns(db: gp.Database, t1: gp.Table, t2: gp.Table):
@@ -74,7 +79,7 @@ def test_join_all_and_one_columns(db: gp.Database, t1: gp.Table, t2: gp.Table):
             )
         )
     )
-    assert ret.column_names() == ["id1", "id2", "idd2", "n2"]
+    assert sorted(ret.column_names()) == sorted(["id1", "id2", "idd2", "n2"])
 
 
 def test_join_columns_from_list(db: gp.Database, t1: gp.Table, t2: gp.Table):
@@ -88,7 +93,7 @@ def test_join_columns_from_list(db: gp.Database, t1: gp.Table, t2: gp.Table):
             )
         )
     )
-    assert ret.column_names() == ["id1", "n1", "idd2"]
+    assert sorted(ret.column_names()) == sorted(["id1", "n1", "idd2"])
 
 
 # FIXME : Test for no exist target column
@@ -99,7 +104,7 @@ def test_join_same_column_using(db: gp.Database):
     t1 = gp.to_table(rows, db=db, column_names=["id"])
     t2 = gp.to_table(rows, db=db, column_names=["id"])
     ret = t1.join(t2, using=["id"], self_columns={"id": "t1_id"}, other_columns={"id": "t2_id"})
-    assert next(iter(ret)).column_names() == ["t1_id", "t2_id"]
+    assert sorted(next(iter(ret)).column_names()) == sorted(["t1_id", "t2_id"])
 
 
 def test_join_same_column_names(db: gp.Database):
@@ -197,7 +202,9 @@ def test_join_natural(db: gp.Database):
         other_columns={"product_name"},
     )
     assert len(list(ret)) == 6
-    assert next(iter(ret)).column_names() == ["category_id", "category_name", "product_name"]
+    assert sorted(next(iter(ret)).column_names()) == sorted(
+        ["category_id", "category_name", "product_name"]
+    )
     for row in ret:
         if row["category_name"] == "Smart Phone":
             assert row["category_id"] == 1
@@ -248,7 +255,14 @@ def test_table_join_save(db: gp.Database, zoo_1: gp.Table):
     )
     t_join.save_as("table_join", temp=True)
     t_join_reload = gp.table("table_join", db=db)
-    assert next(iter(t_join_reload)).column_names() == ["zoo1_animal", "zoo1_id", "zoo2_animal", "zoo2_id"]
+    assert sorted(next(iter(t_join_reload)).column_names()) == sorted(
+        [
+            "zoo1_animal",
+            "zoo1_id",
+            "zoo2_animal",
+            "zoo2_id",
+        ]
+    )
     for row in t_join_reload:
         assert row["zoo1_animal"] == row["zoo2_animal"]
 

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -300,5 +300,5 @@ def test_lineage_dfs_order(db: gp.Database):
     numbers = gp.to_table(rows, db=db, column_names=["val"])
     mod = numbers.assign(mod=lambda t: t["val"] % 2)
     mod3 = mod.assign(mod3=lambda t: t["val"] % 3)
-    results: gp.Table = mod3.join(numbers, using=["val"], self_columns={"val"}, other_columns={})
+    results: gp.Table = mod3.semi_join(numbers, using=["val"])
     assert len(list(results)) == 10


### PR DESCRIPTION
This patch sets the default select columns of join to all. 
It removes also `Table.rename()` so the API can handle itself 
self join, the user doesn't need to handle rename Table.