### PR TITLE
Fix bultin folder not include bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,4 +3,5 @@ import setuptools
 setuptools.setup(
     name="greenplum-python",
     install_requires=["psycopg2==2.9.3"],
+    packages=setuptools.find_packages(),
 )


### PR DESCRIPTION
For the last Beta release, the folder `builtin` containing a list of existing 
GreenpluPython aggregate functions was not included in the package. 
This patch fixes this bug. 