### PR TITLE
Fix Exception raised when result contains NULL

### DIFF
--- a/greenplumpython/table.py
+++ b/greenplumpython/table.py
@@ -202,9 +202,9 @@ class Table:
                 content = [row[c] for c in row]
                 for idx, c in enumerate(content):
                     if isinstance(c, list):
-                        repr_string += ("| {:{}} |").format("{}".format(c if c else "None"), width[idx])  # type: ignore
+                        repr_string += ("| {:{}} |").format("{}".format(c), width[idx])  # type: ignore
                     else:
-                        repr_string += ("| {:{}} |").format(c if c else "None", width[idx])
+                        repr_string += ("| {:{}} |").format(c if c else "", width[idx])
                 repr_string += "\n"
         return repr_string
 
@@ -219,9 +219,13 @@ class Table:
             )
             repr_html_str += "\t</tr>\n"
             for row in self:
-                repr_html_str += "\t<tr>\n"
                 content = [row[c] for c in row]
-                repr_html_str += ("\t\t<td>{:}</td>\n" * len(list(row))).format(*content)
+                repr_html_str += "\t<tr>\n"
+                for idx, c in enumerate(content):
+                    if isinstance(c, list):
+                        repr_html_str += ("\t\t<td>{:}</td>\n").format("{}".format(c))  # type: ignore
+                    else:
+                        repr_html_str += ("\t\t<td>{:}</td>\n").format(c if c else "")
                 repr_html_str += "\t</tr>\n"
             repr_html_str += "</table>"
         return repr_html_str

--- a/greenplumpython/table.py
+++ b/greenplumpython/table.py
@@ -202,9 +202,9 @@ class Table:
                 content = [row[c] for c in row]
                 for idx, c in enumerate(content):
                     if isinstance(c, list):
-                        repr_string += ("| {:{}} |").format("{}".format(c), width[idx])  # type: ignore
+                        repr_string += ("| {:{}} |").format("{}".format(c if c else 'None'), width[idx])  # type: ignore
                     else:
-                        repr_string += ("| {:{}} |").format(c, width[idx])
+                        repr_string += ("| {:{}} |").format(c if c else 'None', width[idx])
                 repr_string += "\n"
         return repr_string
 

--- a/greenplumpython/table.py
+++ b/greenplumpython/table.py
@@ -221,7 +221,7 @@ class Table:
             for row in self:
                 content = [row[c] for c in row]
                 repr_html_str += "\t<tr>\n"
-                for idx, c in enumerate(content):
+                for c in content:
                     if isinstance(c, list):
                         repr_html_str += ("\t\t<td>{:}</td>\n").format("{}".format(c))  # type: ignore
                     else:

--- a/greenplumpython/table.py
+++ b/greenplumpython/table.py
@@ -202,9 +202,9 @@ class Table:
                 content = [row[c] for c in row]
                 for idx, c in enumerate(content):
                     if isinstance(c, list):
-                        repr_string += ("| {:{}} |").format("{}".format(c if c else 'None'), width[idx])  # type: ignore
+                        repr_string += ("| {:{}} |").format("{}".format(c if c else "None"), width[idx])  # type: ignore
                     else:
-                        repr_string += ("| {:{}} |").format(c if c else 'None', width[idx])
+                        repr_string += ("| {:{}} |").format(c if c else "None", width[idx])
                 repr_string += "\n"
         return repr_string
 

--- a/tests/test_const_table.py
+++ b/tests/test_const_table.py
@@ -134,9 +134,9 @@ def test_table_display_result_null(db: gp.Database):
     expected = (
         "| id     || animal |\n"
         "====================\n"
-        "| [1]    || None   |\n"
+        "| [1]    ||        |\n"
         "| [2]    || Tiger  |\n"
-        "| [3]    || None   |\n"
+        "| [3]    ||        |\n"
         "| [None] || Fox    |\n"
     )
     assert str(t.order_by("id")[:]) == expected

--- a/tests/test_const_table.py
+++ b/tests/test_const_table.py
@@ -126,6 +126,22 @@ def test_table_display_repr_empty_result(db: gp.Database):
     assert (t[lambda t: t["id"] == 0]._repr_html_()) == ""
 
 
+def test_table_display_result_null(db: gp.Database):
+    # fmt: off
+    rows = [([1,], None,), ([2,], "Tiger",), ([3,], None,), ([None,], "Fox")]
+    # fmt: on
+    t = gp.to_table(rows, db=db, column_names=["id", "animal"])
+    expected = (
+        "| id     || animal |\n"
+        "====================\n"
+        "| [1]    || None   |\n"
+        "| [2]    || Tiger  |\n"
+        "| [3]    || None   |\n"
+        "| [None] || Fox    |\n"
+    )
+    assert str(t.order_by("id")[:]) == expected
+
+
 def test_table_assign_const(db: gp.Database):
     nums = gp.to_table([(i,) for i in range(10)], db, column_names=["num"])
     results = nums.assign(x=lambda _: "hello")


### PR DESCRIPTION
One row can contain `NULL` values, and it caused problem when we 
want to display the table, because `format()` function can't handle
`None` type. This patch fixes this problem by providing two scenarios:
* if `None` belong to a `list`: display None
* else: display empty