### PR TITLE
Fix psycopg2 with CFLAGS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 psycopg2==2.9.3
+# Pin the setuptools version. The latest one seems to have problem with CFLAGS.
+# See https://github.com/pypa/setuptools/commit/bd7613f7921e8d60fa089d3ab419d0f04db6db6f
+setuptools==63.2.0


### PR DESCRIPTION
psycopg2 contains native code which needs to be build by GCC. however,
the python3 installed on CI is not in a standard directory, the include
path needs to be passed through CFLAGS. This has been addressed by #104.

Some unknown changes changed the version of setuptools being used by tox
to install psycopg2. The latest one doesn't seem to be working well with
CFLAGS. It is probably related to
https://github.com/pypa/setuptools/commit/bd7613f7921e8d60fa089d3ab419d0f04db6db6f

cc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -W
all -fPIC "-DPSYCOPG_VERSION=2.9.3 (dt dec pq3 ext lo64)" -DPSYCOPG_DEBUG=1 -DP
G_VERSION_NUM=90426 -DHAVE_LO64=1 -DPSYCOPG_DEBUG=1 -I/tmp/build/7ca3f3a1/green
plumpython_src/.tox/test_py39/include -I/opt/python-3.9.13/include/python3.9 -I
. -I/usr/local/greenplum-db-devel/include -I/usr/local/greenplum-db-devel/inclu
de/postgresql/server -I/usr/include/libxml2 -I/usr/local/greenplum-db-devel/inc
lude -c psycopg/adapter_asis.c -o build/temp.linux-x86_64-cpython-39/psycopg/ad
apter_asis.o -Wdeclaration-after-statement
      In file included from psycopg/adapter_asis.c:28:0:
      ./psycopg/psycopg.h:35:10: fatal error: Python.h: No such file or directory
       #include <Python.h>
