### PR TITLE
fix: zeros representation in table

### DIFF
--- a/greenplumpython/table.py
+++ b/greenplumpython/table.py
@@ -204,7 +204,7 @@ class Table:
                     if isinstance(c, list):
                         repr_string += ("| {:{}} |").format("{}".format(c), width[idx])  # type: ignore
                     else:
-                        repr_string += ("| {:{}} |").format(c if c else "", width[idx])
+                        repr_string += ("| {:{}} |").format(c if c is not None else "", width[idx])
                 repr_string += "\n"
         return repr_string
 
@@ -225,7 +225,7 @@ class Table:
                     if isinstance(c, list):
                         repr_html_str += ("\t\t<td>{:}</td>\n").format("{}".format(c))  # type: ignore
                     else:
-                        repr_html_str += ("\t\t<td>{:}</td>\n").format(c if c else "")
+                        repr_html_str += ("\t\t<td>{:}</td>\n").format(c if c is not None else "")
                 repr_html_str += "\t</tr>\n"
             repr_html_str += "</table>"
         return repr_html_str

--- a/tests/test_const_table.py
+++ b/tests/test_const_table.py
@@ -68,7 +68,21 @@ def test_table_display_repr(db: gp.Database):
     )
     assert str(t.order_by("id")[:]) == expected
 
-
+def test_table_display_repr_zero(db: gp.Database):
+    # fmt: off
+    rows = [(0, "Lion",), (2, "Tiger",), (3, "Wolf",), (4, "Fox")]
+    # fmt: on
+    t = gp.to_table(rows, db=db, column_names=["id", "animal"])
+    expected = (
+        "| id || animal |\n"
+        "================\n"
+        "|  0 || Lion   |\n"
+        "|  2 || Tiger  |\n"
+        "|  3 || Wolf   |\n"
+        "|  4 || Fox    |\n"
+    )
+    assert str(t.order_by("id")[:]) == expected
+    
 def test_table_display_repr_long_content(db: gp.Database):
     # fmt: off
     rows = [(1, "Lion",), (2, "Tigerrrrrrrrrrrr",), (3, "Wolf",), (4, "Fox")]

--- a/tests/test_const_table.py
+++ b/tests/test_const_table.py
@@ -116,6 +116,7 @@ def test_table_display_result_null(db: gp.Database):
     )
     assert str(t.order_by("id")[:]) == expected
 
+
 def test_table_display_repr_html(db: gp.Database):
     # fmt: off
     rows = [(1, "Lion",), (2, "Tiger",), (3, "Wolf",), (4, "Fox")]

--- a/tests/test_const_table.py
+++ b/tests/test_const_table.py
@@ -68,7 +68,7 @@ def test_table_display_repr(db: gp.Database):
     )
     assert str(t.order_by("id")[:]) == expected
 
-    
+
 def test_table_display_repr_zero(db: gp.Database):
     # fmt: off
     rows = [(0, "Lion",), (2, "Tiger",), (3, "Wolf",), (4, "Fox")]
@@ -84,7 +84,7 @@ def test_table_display_repr_zero(db: gp.Database):
     )
     assert str(t.order_by("id")[:]) == expected
 
-    
+
 def test_table_display_repr_long_content(db: gp.Database):
     # fmt: off
     rows = [(1, "Lion",), (2, "Tigerrrrrrrrrrrr",), (3, "Wolf",), (4, "Fox")]
@@ -99,22 +99,6 @@ def test_table_display_repr_long_content(db: gp.Database):
         "|                    4 || Fox              |\n"
     )
     assert str(t.order_by("iddddddddddddddddddd")[:]) == expected
-
-    
-def test_table_display_result_null(db: gp.Database):
-    # fmt: off
-    rows = [([1,], None,), ([2,], "Tiger",), ([3,], None,), ([None,], "Fox")]
-    # fmt: on
-    t = gp.to_table(rows, db=db, column_names=["id", "animal"])
-    expected = (
-        "| id     || animal |\n"
-        "====================\n"
-        "| [1]    ||        |\n"
-        "| [2]    || Tiger  |\n"
-        "| [3]    ||        |\n"
-        "| [None] || Fox    |\n"
-    )
-    assert str(t.order_by("id")[:]) == expected
 
 
 def test_table_display_repr_html(db: gp.Database):
@@ -156,6 +140,22 @@ def test_table_display_repr_empty_result(db: gp.Database):
     t = gp.to_table(rows, db=db, column_names=["id", "animal"])
     assert str(t[lambda t: t["id"] == 0]) == ""
     assert (t[lambda t: t["id"] == 0]._repr_html_()) == ""
+
+
+def test_table_display_result_null(db: gp.Database):
+    # fmt: off
+    rows = [([1,], None,), ([2,], "Tiger",), ([3,], None,), ([None,], "Fox")]
+    # fmt: on
+    t = gp.to_table(rows, db=db, column_names=["id", "animal"])
+    expected = (
+        "| id     || animal |\n"
+        "====================\n"
+        "| [1]    ||        |\n"
+        "| [2]    || Tiger  |\n"
+        "| [3]    ||        |\n"
+        "| [None] || Fox    |\n"
+    )
+    assert str(t.order_by("id")[:]) == expected
 
 
 def test_table_assign_const(db: gp.Database):
@@ -292,4 +292,3 @@ def test_table_distinct(db: gp.Database):
     assert len(result) == 1
     for row in result:
         assert "i" in row and "j" in row
-

--- a/tests/test_const_table.py
+++ b/tests/test_const_table.py
@@ -98,6 +98,20 @@ def test_table_display_repr_long_content(db: gp.Database):
     )
     assert str(t.order_by("iddddddddddddddddddd")[:]) == expected
 
+def test_table_display_result_null(db: gp.Database):
+    # fmt: off
+    rows = [([1,], None,), ([2,], "Tiger",), ([3,], None,), ([None,], "Fox")]
+    # fmt: on
+    t = gp.to_table(rows, db=db, column_names=["id", "animal"])
+    expected = (
+        "| id     || animal |\n"
+        "====================\n"
+        "| [1]    ||        |\n"
+        "| [2]    || Tiger  |\n"
+        "| [3]    ||        |\n"
+        "| [None] || Fox    |\n"
+    )
+    assert str(t.order_by("id")[:]) == expected
 
 def test_table_display_repr_html(db: gp.Database):
     # fmt: off

--- a/tests/test_const_table.py
+++ b/tests/test_const_table.py
@@ -68,6 +68,7 @@ def test_table_display_repr(db: gp.Database):
     )
     assert str(t.order_by("id")[:]) == expected
 
+    
 def test_table_display_repr_zero(db: gp.Database):
     # fmt: off
     rows = [(0, "Lion",), (2, "Tiger",), (3, "Wolf",), (4, "Fox")]
@@ -83,6 +84,7 @@ def test_table_display_repr_zero(db: gp.Database):
     )
     assert str(t.order_by("id")[:]) == expected
 
+    
 def test_table_display_repr_long_content(db: gp.Database):
     # fmt: off
     rows = [(1, "Lion",), (2, "Tigerrrrrrrrrrrr",), (3, "Wolf",), (4, "Fox")]
@@ -98,6 +100,7 @@ def test_table_display_repr_long_content(db: gp.Database):
     )
     assert str(t.order_by("iddddddddddddddddddd")[:]) == expected
 
+    
 def test_table_display_result_null(db: gp.Database):
     # fmt: off
     rows = [([1,], None,), ([2,], "Tiger",), ([3,], None,), ([None,], "Fox")]
@@ -288,3 +291,4 @@ def test_table_distinct(db: gp.Database):
     assert len(result) == 1
     for row in result:
         assert "i" in row and "j" in row
+

--- a/tests/test_const_table.py
+++ b/tests/test_const_table.py
@@ -82,7 +82,7 @@ def test_table_display_repr_zero(db: gp.Database):
         "|  4 || Fox    |\n"
     )
     assert str(t.order_by("id")[:]) == expected
-    
+
 def test_table_display_repr_long_content(db: gp.Database):
     # fmt: off
     rows = [(1, "Lion",), (2, "Tigerrrrrrrrrrrr",), (3, "Wolf",), (4, "Fox")]
@@ -138,22 +138,6 @@ def test_table_display_repr_empty_result(db: gp.Database):
     t = gp.to_table(rows, db=db, column_names=["id", "animal"])
     assert str(t[lambda t: t["id"] == 0]) == ""
     assert (t[lambda t: t["id"] == 0]._repr_html_()) == ""
-
-
-def test_table_display_result_null(db: gp.Database):
-    # fmt: off
-    rows = [([1,], None,), ([2,], "Tiger",), ([3,], None,), ([None,], "Fox")]
-    # fmt: on
-    t = gp.to_table(rows, db=db, column_names=["id", "animal"])
-    expected = (
-        "| id     || animal |\n"
-        "====================\n"
-        "| [1]    ||        |\n"
-        "| [2]    || Tiger  |\n"
-        "| [3]    ||        |\n"
-        "| [None] || Fox    |\n"
-    )
-    assert str(t.order_by("id")[:]) == expected
 
 
 def test_table_assign_const(db: gp.Database):


### PR DESCRIPTION
Noticed that Zeros (0) are not shown in the actual state because __repr__ and _repr_html_ are using "if c" condition instead of "if c is not None" 