### PR TITLE
Lint for python docstr

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,5 @@ isort==5.10.1
 pytest==7.0.1
 pglast==3.10
 pyright==1.1.250
+pydocstyle==6.2.3
 pandas

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,5 +3,4 @@ isort==5.10.1
 pytest==7.0.1
 pglast==3.10
 pyright==1.1.250
-pydocstyle==6.2.3
 pandas

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -3,4 +3,5 @@ sphinx==5.1.1
 sphinx_rtd_theme==1.0.0
 nbsphinx
 ipython~=8.6.0
+pydocstyle==6.2.3
 pandoc

--- a/tox.ini
+++ b/tox.ini
@@ -53,3 +53,10 @@ commands =
     # fix problem for macos when building docs in local evironment
     pip install --force-reinstall psycopg2-binary
     sphinx-build -W --keep-going -b html -j 2 {toxinidir}/doc/source doc/build/{env:TAG_REF:}
+
+[testenv:docstyle]
+basepython = python3.9
+deps = {[base]deps}
+skip_install = true
+commands =
+    pydocstyle {posargs:greenplumpython}


### PR DESCRIPTION
- Add tox target docstyle which uses pydocstyle to lint python doc
  strings. See https://github.com/PyCQA/pydocstyle and
  http://www.python.org/dev/peps/pep-0257/
  'tox -e docstyle' will check all py files in greenplumpython
  directory.
  Use 'tox -e docstyle -- <path_to_the_py_file>' to lint individual py
  source file.
- The doc linter has not been enabled on CI yet. It will be done in
  another PR later.
