### PR TITLE
Doc modification for pandas comparison

### DIFF
--- a/doc/source/notebooks/pandas.ipynb
+++ b/doc/source/notebooks/pandas.ipynb
@@ -38,6 +38,7 @@
    "metadata": {},
    "source": [
     "However, due to the discrepency in the purposes they serve, that is,\n",
+    "\n",
     "- GreenplumPython is an interface to a remote database system, while\n",
     "- pandas is a library for manipulating local in-memory data\n",
     "\n",
@@ -48,6 +49,7 @@
     "## Data Structure\n",
     "\n",
     "The core data structure of GreenplumPython, `DataFrame`, is fundamentally similar to `Dataframe` in pandas in that\n",
+    "\n",
     "- Data are organized into rows and columns;\n",
     "- Columns can be of different types, and can be accessed by name;\n",
     "- Rows are of the same type, and are iterable.\n",
@@ -150,8 +152,8 @@
     }
    ],
    "source": [
-    "df = pd.DataFrame.from_records(students, columns=[\"name\", \"age\"])\n",
-    "df"
+    "pd_df = pd.DataFrame.from_records(students, columns=[\"name\", \"age\"])\n",
+    "pd_df"
    ]
   },
   {
@@ -189,11 +191,11 @@
        "</table>"
       ],
       "text/plain": [
-       "| name  || age |\n",
-       "================\n",
-       "| alice ||  18 |\n",
-       "| bob   ||  19 |\n",
-       "| carol ||  19 |"
+       " name  | age \n",
+       " ----- + --- \n",
+       " alice |  18 \n",
+       " bob   |  19 \n",
+       " carol |  19 "
       ]
      },
      "execution_count": 4,
@@ -203,8 +205,8 @@
    ],
    "source": [
     "db = gp.database(dbname=\"gpadmin\")\n",
-    "t = gp.DataFrame.from_rows(students, column_names=[\"name\", \"age\"], db=db)\n",
-    "t"
+    "gp_df = gp.DataFrame.from_rows(students, column_names=[\"name\", \"age\"], db=db)\n",
+    "gp_df"
    ]
   },
   {
@@ -212,12 +214,14 @@
    "metadata": {},
    "source": [
     "But here is an important **difference**:\n",
+    "\n",
     "- a `DataFrame` in GreenplumPython must be created in a database, while\n",
     "- pandas does not have the concept of \"database\".\n",
     "\n",
     "`Database` in GreenplumPython is like \"directory\" in file systems, which helps to avoid name conflict on persistence.\n",
     "\n",
     "The reason behind this difference is that\n",
+    "\n",
     "- `DataFrame`s in GreenplumPython can themselves be persisted, while\n",
     "- `DataFrame`s in pandas live only in memory and need to be written to a file for persistence.\n",
     "\n",
@@ -252,11 +256,11 @@
        "</table>"
       ],
       "text/plain": [
-       "| name  || age |\n",
-       "================\n",
-       "| bob   ||  19 |\n",
-       "| carol ||  19 |\n",
-       "| alice ||  18 |"
+       " name  | age \n",
+       " ----- + --- \n",
+       " bob   |  19 \n",
+       " carol |  19 \n",
+       " alice |  18 "
       ]
      },
      "execution_count": 5,
@@ -265,7 +269,7 @@
     }
    ],
    "source": [
-    "t.save_as(\"student\", temp=True)"
+    "gp_df.save_as(\"student\", column_names=[\"name\", \"age\"], temp=True)"
    ]
   },
   {
@@ -281,15 +285,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df.to_csv(\"/tmp/student.csv\")"
+    "pd_df.to_csv(\"/tmp/student.csv\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Saving a `DataFrame` with `temp=True` in GreenplumPython is similar to saving a `DataFrame` into the `/tmp` directory in pandas\n",
-    "- GreenplumPython `DataFrame`s saved with `temp=True` will be dropped automatically by the database system, while\n",
+    "Saving a `DataFrame` with `temp=True` in GreenplumPython is similar to saving a `DataFrame` into the `/tmp` directory in pandas:\n",
+    "\n",
+    "- GreenplumPython `DataFrame`s saved with `temp=True` will be dropped automatically by the database system when the database session is terminated, while\n",
     "- pandas `DataFrame`s saved in `/tmp` will be clean automatically by the operating system."
    ]
   },
@@ -314,6 +319,10 @@
        "\t\t<th>age</th>\n",
        "\t</tr>\n",
        "\t<tr>\n",
+       "\t\t<td>alice</td>\n",
+       "\t\t<td>18</td>\n",
+       "\t</tr>\n",
+       "\t<tr>\n",
        "\t\t<td>bob</td>\n",
        "\t\t<td>19</td>\n",
        "\t</tr>\n",
@@ -321,18 +330,14 @@
        "\t\t<td>carol</td>\n",
        "\t\t<td>19</td>\n",
        "\t</tr>\n",
-       "\t<tr>\n",
-       "\t\t<td>alice</td>\n",
-       "\t\t<td>18</td>\n",
-       "\t</tr>\n",
        "</table>"
       ],
       "text/plain": [
-       "| name  || age |\n",
-       "================\n",
-       "| bob   ||  19 |\n",
-       "| carol ||  19 |\n",
-       "| alice ||  18 |"
+       " name  | age \n",
+       " ----- + --- \n",
+       " alice |  18 \n",
+       " bob   |  19 \n",
+       " carol |  19 "
       ]
      },
      "execution_count": 7,
@@ -449,7 +454,7 @@
     }
    ],
    "source": [
-    "for row in t:\n",
+    "for row in gp_df:\n",
     "    print(row[\"name\"], row[\"age\"])"
    ]
   },
@@ -476,7 +481,7 @@
     }
    ],
    "source": [
-    "for row in df.iterrows():\n",
+    "for row in pd_df.iterrows():\n",
     "    print(row[1][\"name\"], row[1][\"age\"])"
    ]
   },
@@ -574,7 +579,7 @@
     }
    ],
    "source": [
-    "df[[\"name\", \"age\"]]"
+    "pd_df[[\"name\", \"age\"]]"
    ]
   },
   {
@@ -598,6 +603,10 @@
        "\t\t<th>age</th>\n",
        "\t</tr>\n",
        "\t<tr>\n",
+       "\t\t<td>alice</td>\n",
+       "\t\t<td>18</td>\n",
+       "\t</tr>\n",
+       "\t<tr>\n",
        "\t\t<td>bob</td>\n",
        "\t\t<td>19</td>\n",
        "\t</tr>\n",
@@ -605,18 +614,14 @@
        "\t\t<td>carol</td>\n",
        "\t\t<td>19</td>\n",
        "\t</tr>\n",
-       "\t<tr>\n",
-       "\t\t<td>alice</td>\n",
-       "\t\t<td>18</td>\n",
-       "\t</tr>\n",
        "</table>"
       ],
       "text/plain": [
-       "| name  || age |\n",
-       "================\n",
-       "| bob   ||  19 |\n",
-       "| carol ||  19 |\n",
-       "| alice ||  18 |"
+       " name  | age \n",
+       " ----- + --- \n",
+       " alice |  18 \n",
+       " bob   |  19 \n",
+       " carol |  19 "
       ]
      },
      "execution_count": 12,
@@ -666,7 +671,7 @@
     }
    ],
    "source": [
-    "df[\"name\"]"
+    "pd_df[\"name\"]"
    ]
   },
   {
@@ -684,7 +689,7 @@
     {
      "data": {
       "text/plain": [
-       "<greenplumpython.col.Column at 0x7f0b8448ed30>"
+       "<greenplumpython.col.Column at 0x7f99919172b0>"
       ]
      },
      "execution_count": 14,
@@ -693,7 +698,7 @@
     }
    ],
    "source": [
-    "t[\"name\"]"
+    "gp_df[\"name\"]"
    ]
   },
   {
@@ -701,12 +706,14 @@
    "metadata": {},
    "source": [
     "But you might notice the **difference** here:\n",
+    "\n",
     "- for pandas, using the `[]` operator gives us the data immediately if we refer to a column, while\n",
     "- for GreenplumPython, it only gives a `Column` object. `Column` is supposed to be used for computation rather than for observing data.\n",
     "\n",
-    "The reasons behind this difference are\n",
+    "The reasons behind this difference are:\n",
+    "\n",
     "- Database systems behind GreenplumPython does not provide native one-dimensional data structure like `Series` in pandas.\n",
-    "- It is much more efficient to retrieve all columns needed in a GreenplumPython `DataFrame` at once than one at a time. We will see later how to add new columns to a GreenplumPython `DataFrame` so that they can be retrived all at once."
+    "- It is much more efficient to retrieve all columns needed in a GreenplumPython `DataFrame` at once than one at a time. We will see later how to add new columns to a GreenplumPython `DataFrame` so that they can be retrieved all at once."
    ]
   },
   {
@@ -717,7 +724,7 @@
     "\n",
     "The `[]` operator can also be used to select a subset of rows, a.k.a filtering.\n",
     "\n",
-    "Say we want the infomation of student named \"alice\", with pandas we can do"
+    "Say we want the information of student named \"alice\", with pandas we can do"
    ]
   },
   {
@@ -771,7 +778,7 @@
     }
    ],
    "source": [
-    "df[lambda df: df[\"name\"] == \"alice\"]"
+    "pd_df[lambda df: df[\"name\"] == \"alice\"]"
    ]
   },
   {
@@ -801,9 +808,9 @@
        "</table>"
       ],
       "text/plain": [
-       "| name  || age |\n",
-       "================\n",
-       "| alice ||  18 |"
+       " name  | age \n",
+       " ----- + --- \n",
+       " alice |  18 "
       ]
      },
      "execution_count": 16,
@@ -821,7 +828,7 @@
    "source": [
     "Here we see how a column in GreenplumPython, `t[\"name\"]` in this case, is used for computation to form a more complex expression.\n",
     "\n",
-    "In this example, When the expression `t[\"name\"] == \"alice\"` is evaluated, `t` will be bound to the \"current\" dataframe, i.e. `student`.\n",
+    "In this example, When the expression `t[\"name\"] == \"alice\"` is evaluated, `t` will be bound to the **current** dataframe, i.e. `student`.\n",
     "\n",
     "GreenplumPython provides such a functional interface so that the user does not have to refer to the possibly long intermediate variable name like `student` again and again when the expression becomes complicated."
    ]
@@ -863,10 +870,10 @@
        "</table>"
       ],
       "text/plain": [
-       "| name  || age |\n",
-       "================\n",
-       "| alice ||  18 |\n",
-       "| bob   ||  19 |"
+       " name  | age \n",
+       " ----- + --- \n",
+       " alice |  18 \n",
+       " bob   |  19 "
       ]
      },
      "execution_count": 17,
@@ -942,7 +949,7 @@
     }
    ],
    "source": [
-    "df[:2]"
+    "pd_df[:2]"
    ]
   },
   {
@@ -950,6 +957,7 @@
    "metadata": {},
    "source": [
     "But you might notice the **difference**: When selecting rows,\n",
+    "\n",
     "- for pandas, rows in the output `DataFrame` preserves the same order as the input, while\n",
     "- for GreenplumPython, the order of rows in `DataFrame` might not be preserved.\n",
     "\n",
@@ -1038,7 +1046,7 @@
     }
    ],
    "source": [
-    "df.sort_values([\"age\", \"name\"], ascending=[False, False])"
+    "pd_df.sort_values([\"age\", \"name\"], ascending=[False, False])"
    ]
   },
   {
@@ -1076,11 +1084,11 @@
        "</table>"
       ],
       "text/plain": [
-       "| name  || age |\n",
-       "================\n",
-       "| carol ||  19 |\n",
-       "| bob   ||  19 |\n",
-       "| alice ||  18 |"
+       " name  | age \n",
+       " ----- + --- \n",
+       " carol |  19 \n",
+       " bob   |  19 \n",
+       " alice |  18 "
       ]
      },
      "execution_count": 20,
@@ -1097,6 +1105,7 @@
    "metadata": {},
    "source": [
     "There are some important **difference** compared with pandas:\n",
+    "\n",
     "- GreenplumPython does not provide something like `DataFrame.sort_index()` in pandas, because unlike `DataFrame`s in pandas, `DataFrame` in GreenplumPython does not have an \"index column\".\n",
     "- `DataFrame.order_by()` supports chaining to specify multiple ordering columns. We think that compared to passing lists, method chaining is simpler because it is not required to remember the order of columns in the list. "
    ]
@@ -1111,7 +1120,8 @@
     "\n",
     "A new column may contains data resulting from whatever computation we want. \n",
     "\n",
-    "Both GreeplumPython and pandas support transforming columns by adding a new column. Specifically, we need to\n",
+    "Both GreeplumPython and pandas support transforming columns by adding a new column. Specifically, we need to:\n",
+    "\n",
     "- define the transfomation as an expression, and then\n",
     "- bind the expression to a new column of the source `DataFrame` or `DataFrame` to form a new one.\n",
     "\n",
@@ -1156,19 +1166,19 @@
        "      <th>0</th>\n",
        "      <td>alice</td>\n",
        "      <td>18</td>\n",
-       "      <td>2004</td>\n",
+       "      <td>2005</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>bob</td>\n",
        "      <td>19</td>\n",
-       "      <td>2003</td>\n",
+       "      <td>2004</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>carol</td>\n",
        "      <td>19</td>\n",
-       "      <td>2003</td>\n",
+       "      <td>2004</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1176,9 +1186,9 @@
       ],
       "text/plain": [
        "    name  age  year_of_birth\n",
-       "0  alice   18           2004\n",
-       "1    bob   19           2003\n",
-       "2  carol   19           2003"
+       "0  alice   18           2005\n",
+       "1    bob   19           2004\n",
+       "2  carol   19           2004"
       ]
      },
      "execution_count": 21,
@@ -1190,7 +1200,7 @@
     "import datetime \n",
     "\n",
     "this_year = datetime.date.today().year\n",
-    "df.assign(year_of_birth=lambda df: -df[\"age\"] + this_year)"
+    "pd_df.assign(year_of_birth=lambda df: -df[\"age\"] + this_year)"
    ]
   },
   {
@@ -1217,26 +1227,26 @@
        "\t<tr>\n",
        "\t\t<td>alice</td>\n",
        "\t\t<td>18</td>\n",
-       "\t\t<td>2004</td>\n",
+       "\t\t<td>2005</td>\n",
        "\t</tr>\n",
        "\t<tr>\n",
        "\t\t<td>bob</td>\n",
        "\t\t<td>19</td>\n",
-       "\t\t<td>2003</td>\n",
+       "\t\t<td>2004</td>\n",
        "\t</tr>\n",
        "\t<tr>\n",
        "\t\t<td>carol</td>\n",
        "\t\t<td>19</td>\n",
-       "\t\t<td>2003</td>\n",
+       "\t\t<td>2004</td>\n",
        "\t</tr>\n",
        "</table>"
       ],
       "text/plain": [
-       "| name  || age || year_of_birth |\n",
-       "=================================\n",
-       "| alice ||  18 ||          2004 |\n",
-       "| bob   ||  19 ||          2003 |\n",
-       "| carol ||  19 ||          2003 |"
+       " name  | age | year_of_birth \n",
+       " ----- + --- + ------------- \n",
+       " alice |  18 |          2005 \n",
+       " bob   |  19 |          2004 \n",
+       " carol |  19 |          2004 "
       ]
      },
      "execution_count": 22,
@@ -1294,6 +1304,11 @@
        "\t\t<th>name_</th>\n",
        "\t</tr>\n",
        "\t<tr>\n",
+       "\t\t<td>alice</td>\n",
+       "\t\t<td>18</td>\n",
+       "\t\t<td>2bd806c97f0e00af1a1fc3328fa763a9269723c8db8fac4f93af71db186d6e90</td>\n",
+       "\t</tr>\n",
+       "\t<tr>\n",
        "\t\t<td>bob</td>\n",
        "\t\t<td>19</td>\n",
        "\t\t<td>81b637d8fcd2c6da6359e6963113a1170de795e4b725b84d1e0b4cfd9ec58ce9</td>\n",
@@ -1303,19 +1318,14 @@
        "\t\t<td>19</td>\n",
        "\t\t<td>4c26d9074c27d89ede59270c0ac14b71e071b15239519f75474b2f3ba63481f5</td>\n",
        "\t</tr>\n",
-       "\t<tr>\n",
-       "\t\t<td>alice</td>\n",
-       "\t\t<td>18</td>\n",
-       "\t\t<td>2bd806c97f0e00af1a1fc3328fa763a9269723c8db8fac4f93af71db186d6e90</td>\n",
-       "\t</tr>\n",
        "</table>"
       ],
       "text/plain": [
-       "| name  || age || name_                                                            |\n",
-       "====================================================================================\n",
-       "| bob   ||  19 || 81b637d8fcd2c6da6359e6963113a1170de795e4b725b84d1e0b4cfd9ec58ce9 |\n",
-       "| carol ||  19 || 4c26d9074c27d89ede59270c0ac14b71e071b15239519f75474b2f3ba63481f5 |\n",
-       "| alice ||  18 || 2bd806c97f0e00af1a1fc3328fa763a9269723c8db8fac4f93af71db186d6e90 |"
+       " name  | age | name_                                                            \n",
+       " ----- + --- + ---------------------------------------------------------------- \n",
+       " alice |  18 | 2bd806c97f0e00af1a1fc3328fa763a9269723c8db8fac4f93af71db186d6e90 \n",
+       " bob   |  19 | 81b637d8fcd2c6da6359e6963113a1170de795e4b725b84d1e0b4cfd9ec58ce9 \n",
+       " carol |  19 | 4c26d9074c27d89ede59270c0ac14b71e071b15239519f75474b2f3ba63481f5 "
       ]
      },
      "execution_count": 24,
@@ -1366,11 +1376,11 @@
        "</table>"
       ],
       "text/plain": [
-       "| name                                                             || age |\n",
-       "===========================================================================\n",
-       "| 2bd806c97f0e00af1a1fc3328fa763a9269723c8db8fac4f93af71db186d6e90 ||  18 |\n",
-       "| 81b637d8fcd2c6da6359e6963113a1170de795e4b725b84d1e0b4cfd9ec58ce9 ||  19 |\n",
-       "| 4c26d9074c27d89ede59270c0ac14b71e071b15239519f75474b2f3ba63481f5 ||  19 |"
+       " name                                                             | age \n",
+       " ---------------------------------------------------------------- + --- \n",
+       " 2bd806c97f0e00af1a1fc3328fa763a9269723c8db8fac4f93af71db186d6e90 |  18 \n",
+       " 81b637d8fcd2c6da6359e6963113a1170de795e4b725b84d1e0b4cfd9ec58ce9 |  19 \n",
+       " 4c26d9074c27d89ede59270c0ac14b71e071b15239519f75474b2f3ba63481f5 |  19 "
       ]
      },
      "execution_count": 25,
@@ -1461,7 +1471,7 @@
     }
    ],
    "source": [
-    "df.apply(lambda df: hide_name(df[\"name\"], df[\"age\"]), axis=1, result_type=\"expand\")"
+    "pd_df.apply(lambda df: hide_name(df[\"name\"], df[\"age\"]), axis=1, result_type=\"expand\")"
    ]
   },
   {
@@ -1469,8 +1479,9 @@
    "metadata": {},
    "source": [
     "But there are still some important **differences** between the two cases:\n",
+    "\n",
     "- In pandas, what we apply to a `DataFrame` is a Python function, while in GreenplumPython, a Python function must be converted to a database function before being applied to a `DataFrame`.\n",
-    "- pandas supports applying a function along different axes, while GreenplumPython only support applying a function to each row due to the limitation of the database system behind."
+    "- pandas supports applying a function along different axes, while GreenplumPython only supports applying a function to each row due to the limitation of the database system behind.\n"
    ]
   },
   {
@@ -1508,7 +1519,7 @@
    "source": [
     "import numpy as np\n",
     "\n",
-    "df.groupby(\"age\").apply(lambda df: np.count_nonzero(df[\"name\"]))"
+    "pd_df.groupby(\"age\").apply(lambda df: np.count_nonzero(df[\"name\"]))"
    ]
   },
   {
@@ -1542,10 +1553,10 @@
        "</table>"
       ],
       "text/plain": [
-       "| count || age |\n",
-       "================\n",
-       "|     2 ||  19 |\n",
-       "|     1 ||  18 |"
+       " count | age \n",
+       " ----- + --- \n",
+       "     2 |  19 \n",
+       "     1 |  18 "
       ]
      },
      "execution_count": 28,
@@ -1576,7 +1587,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -1625,13 +1636,13 @@
        "1    bob   19"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "df.drop_duplicates(\"age\")"
+    "pd_df.drop_duplicates(\"age\")"
    ]
   },
   {
@@ -1643,7 +1654,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -1665,13 +1676,13 @@
        "</table>"
       ],
       "text/plain": [
-       "| name  || age |\n",
-       "================\n",
-       "| alice ||  18 |\n",
-       "| carol ||  19 |"
+       " name  | age \n",
+       " ----- + --- \n",
+       " alice |  18 \n",
+       " carol |  19 "
       ]
      },
-     "execution_count": 31,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1691,7 +1702,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
@@ -1707,12 +1718,12 @@
        "</table>"
       ],
       "text/plain": [
-       "| count |\n",
-       "=========\n",
-       "|     2 |"
+       " count \n",
+       " ----- \n",
+       "     2 "
       ]
      },
-     "execution_count": 32,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1738,7 +1749,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
@@ -1811,13 +1822,13 @@
        "4  carol   19  carol"
       ]
      },
-     "execution_count": 55,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "df.merge(df, on=\"age\", suffixes=(\"\", \"_2\"))"
+    "pd_df.merge(pd_df, on=\"age\", suffixes=(\"\", \"_2\"))"
    ]
   },
   {
@@ -1829,7 +1840,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
@@ -1847,14 +1858,14 @@
        "\t\t<td>carol</td>\n",
        "\t</tr>\n",
        "\t<tr>\n",
-       "\t\t<td>carol</td>\n",
+       "\t\t<td>bob</td>\n",
        "\t\t<td>19</td>\n",
-       "\t\t<td>carol</td>\n",
+       "\t\t<td>bob</td>\n",
        "\t</tr>\n",
        "\t<tr>\n",
-       "\t\t<td>bob</td>\n",
+       "\t\t<td>carol</td>\n",
        "\t\t<td>19</td>\n",
-       "\t\t<td>bob</td>\n",
+       "\t\t<td>carol</td>\n",
        "\t</tr>\n",
        "\t<tr>\n",
        "\t\t<td>carol</td>\n",
@@ -1869,23 +1880,24 @@
        "</table>"
       ],
       "text/plain": [
-       "| name  || age || name_2 |\n",
-       "==========================\n",
-       "| bob   ||  19 || carol  |\n",
-       "| carol ||  19 || carol  |\n",
-       "| bob   ||  19 || bob    |\n",
-       "| carol ||  19 || bob    |\n",
-       "| alice ||  18 || alice  |"
+       " name  | age | name_2 \n",
+       " ----- + --- + ------ \n",
+       " bob   |  19 | carol  \n",
+       " bob   |  19 | bob    \n",
+       " carol |  19 | carol  \n",
+       " carol |  19 | bob    \n",
+       " alice |  18 | alice  "
       ]
      },
-     "execution_count": 56,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
+    "student_2 = student.save_as(dataframe_name=\"students_2\", column_names=[\"name\", \"age\"], temp=True)\n",
     "student.join(\n",
-    "    student.rename(\"student_2\"),\n",
+    "    student_2,\n",
     "    using=[\"age\"],\n",
     "    self_columns={\"*\"},\n",
     "    other_columns={\"name\": \"name_2\"},\n",
@@ -1905,7 +1917,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
@@ -1966,7 +1978,7 @@
        "4    9"
       ]
      },
-     "execution_count": 60,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1990,7 +2002,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.9.13 64-bit",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -2004,9 +2016,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.9"
   },
-  "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
     "hash": "aee8b7b246df8f9039afb4144a1f6fd8d2ca17a180786b69acc140d282b71a49"
@@ -2014,5 +2025,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
- Typos and punctuations.
- Blank lines to make bullet work in markdown.
- Code changes due to API changes.
- Distinguish the dataframe in pandas and GrenplumPython by prefix,
  `pdf` and `gdf`.