### PR TITLE
Change psycopg2 package to binary

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -19,6 +19,7 @@ There are explanations about the implementation and examples.
    :maxdepth: 2
    :caption: Contents:
 
+   requirements
    install
    basic
    modules

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -17,5 +17,3 @@ To install the latest development version, do
 NOTE: This version is considered UNSTABLE. DON'T use it in the production environment!
 
 Stable version will be released soon.
-
-NOTE: The lowest Python version supported by GreenplumPython is Python3.9!

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -17,3 +17,5 @@ To install the latest development version, do
 NOTE: This version is considered UNSTABLE. DON'T use it in the production environment!
 
 Stable version will be released soon.
+
+NOTE: The lowest Python version supported by GreenplumPython is Python3.9!

--- a/doc/source/requirements.rst
+++ b/doc/source/requirements.rst
@@ -1,0 +1,12 @@
+Requirements
+============
+
+GreenplumPython currently requires **at least Python 3.9** to run, this is because:
+    * Python 3.9 is the version we officially support and release with PL/Python3 and GPDB 6.
+    * Python 3.9 is the default version in Rocky Linux 9 and is officially supported in Rocky Linux 8 (and also probably in RHEL 8).
+
+As a dependency of GreenplumPython, psycopg2 is a source package. To install it, the client side need to have
+    * libpq and its C header files,
+    * C compilers, such as gcc
+installed so that the C code in the psycopg2 package can be compiled. To sidestep this problem, we change
+our dependency to psycopg2-binary, which is a binary package.

--- a/doc/source/requirements.rst
+++ b/doc/source/requirements.rst
@@ -1,12 +1,13 @@
 Requirements
 ============
 
-GreenplumPython currently requires **at least Python 3.9** to run, this is because:
+GreenplumPython currently requires at least Python 3.9 to run, this is because:
     * Python 3.9 is the version we officially support and release with PL/Python3 and GPDB 6.
     * Python 3.9 is the default version in Rocky Linux 9 and is officially supported in Rocky Linux 8 (and also probably in RHEL 8).
 
 As a dependency of GreenplumPython, psycopg2 is a source package. To install it, the client side need to have
     * libpq and its C header files,
     * C compilers, such as gcc
+
 installed so that the C code in the psycopg2 package can be compiled. To sidestep this problem, we change
 our dependency to psycopg2-binary, which is a binary package.

--- a/greenplumpython/col.py
+++ b/greenplumpython/col.py
@@ -82,6 +82,7 @@ class Column(Expr):
 
     def __getitem__(self, field_name: str) -> ColumnField:
         """
+        Used when want to use Field of Column for computation.
         Returns :class:`ColumnField` of self by matching field_name
 
         Args:

--- a/greenplumpython/db.py
+++ b/greenplumpython/db.py
@@ -48,10 +48,12 @@ class Database:
             Optional[Iterable]: None or result of SQL query
 
         Example:
-            .. code-block::  Python
+            .. highlight:: python
+            .. code-block::  python
 
-                result = db.execute("SELECT version()")
-
+                >>> version = db.execute("SELECT version()")
+                >>> db.assign(version=lambda: version())
+                PostgreSQL 12.9 (Debian 12.9-1.pgdg110+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit
         """
 
         with self._conn.cursor() as cursor:
@@ -82,33 +84,33 @@ class Database:
             columns: Dict[str, List[Any]]: a dict of columns
             column_names: Iterable[str]: List of given column names
 
-        Returns:
-        .. highlight:: python
-        .. code-block::  python
+        Example:
+            .. highlight:: python
+            .. code-block::  python
 
-            >>> t_from_table = db.create_dataframe(table_name="pg_class")
-            >>> rows = [(1,), (2,), (3,)]
-            >>> t_from_rows = db.create_dataframe(rows=rows, column_names=["id"])
-            >>> t_from_rows
-            ----
-             id
-            ----
-              1
-              2
-              3
-            ----
-            (3 rows)
-            >>> columns = {"a": [1, 2, 3], "b": [1, 2, 3]}
-            >>> t_from_columns = db.create_dataframe(columns=columns)
-            >>> t_from_columns
-            -------
-             a | b
-            ---+---
-             1 | 1
-             2 | 2
-             3 | 3
-            -------
-            (3 rows)
+                >>> df_from_table = db.create_dataframe(table_name="pg_class")
+                >>> rows = [(1,), (2,), (3,)]
+                >>> df_from_rows = db.create_dataframe(rows=rows, column_names=["id"])
+                >>> df_from_rows
+                ----
+                 id
+                ----
+                  1
+                  2
+                  3
+                ----
+                (3 rows)
+                >>> columns = {"a": [1, 2, 3], "b": [1, 2, 3]}
+                >>> t_from_columns = db.create_dataframe(columns=columns)
+                >>> t_from_columns
+                -------
+                 a | b
+                ---+---
+                 1 | 1
+                 2 | 2
+                 3 | 3
+                -------
+                (3 rows)
 
         """
         from greenplumpython.dataframe import DataFrame
@@ -131,7 +133,7 @@ class Database:
         as_name: Optional[str] = None,
     ) -> "DataFrame":
         """
-        Apply a function in database.
+        Apply a function in database without dependencies on table.
 
         Args:
             func: An aggregate function to be applied to

--- a/greenplumpython/func.py
+++ b/greenplumpython/func.py
@@ -310,9 +310,10 @@ class NormalFunction(_AbstractFunction):
 
 def function(name: str, schema: Optional[str] = None) -> NormalFunction:
     """
-    A wrap in order to call function
+    A wrap in order to call function (Predefined in-Database UDF) on :class:`~db.Dataframe`.
 
     Example:
+        Get a wrapper of the in-Database function `generate_series`
         .. code-block::  Python
 
             generate_series = gp.function("generate_series")
@@ -402,7 +403,7 @@ class AggregateFunction(_AbstractFunction):
 
 def aggregate_function(name: str, schema: Optional[str] = None) -> AggregateFunction:
     """
-    A wrap in order to call an aggregate function
+    A wrap in order to call an aggregate function (Predefined in-Database UDA).
 
     Example:
         .. code-block::  Python
@@ -417,8 +418,7 @@ def create_function(
     wrapped_func: Optional[Callable[..., Any]] = None, language_handler: str = "plpython3u"
 ) -> NormalFunction:
     """
-    Creates a User Defined Function (UDF) in database from the given Python
-    function.
+    Creates a User Defined Function (UDF) in database from the given Python function.
 
     Args:
         wrapped_func : the Python function to be wrapped into a database function
@@ -456,8 +456,7 @@ def create_aggregate(
     transition_func: Optional[Callable[..., Any]] = None, language_handler: str = "plpython3u"
 ) -> AggregateFunction:
     """
-    Creates a User Defined Aggregate (UDA) in Database using the given Python
-    function as the state transition function.
+    Creates a User Defined Aggregate (UDA) in Database using the given Python function as the state transition function.
 
     Args:
         transition_func : python function
@@ -511,8 +510,7 @@ def create_array_function(
     wrapped_func: Optional[Callable[..., Any]] = None, language_handler: str = "plpython3u"
 ) -> ArrayFunction:
     """
-    Creates a User Defined Array Function in database from the given Python
-    function.
+    Creates a User Defined Array Function in database from the given Python function.
 
     Args:
         wrapped_func: python function

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-psycopg2==2.9.3
+psycopg2-binary==2.9.5
 # Pin the setuptools version. The latest one seems to have problem with CFLAGS.
 # See https://github.com/pypa/setuptools/commit/bd7613f7921e8d60fa089d3ab419d0f04db6db6f
 setuptools==65.5.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,4 +14,4 @@ classifiers =
 [options]
 packages = find:
 include_package_data = True
-python_requires = >= 3.8
+python_requires = >= 3.9

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,6 @@ import setuptools
 
 setuptools.setup(
     name="greenplum-python",
-    install_requires=["psycopg2==2.9.3"],
+    install_requires=["psycopg2-binary==2.9.5"],
     packages=setuptools.find_packages(),
 )


### PR DESCRIPTION
As a dependency of GreenplumPython, psycopg2 is a source package. To install it, the client side 
need to have
    * libpq and its C header files,
    * C compilers, such as gcc

installed so that the C code in the psycopg2 package can be compiled. This can be complicated 
to handle different system environment, to sidestep this problem, we change our dependency to 
psycopg2-binary, which is a binary package.

This patch adds also more examples and explaination in documentation. And change the lowest python 
version requirement to Python3.9.