### PR TITLE
add 'with' storage_parameters options for save_as

### DIFF
--- a/greenplumpython/dataframe.py
+++ b/greenplumpython/dataframe.py
@@ -885,11 +885,8 @@ class DataFrame:
             dataframe_name : str
             temp : bool : if table is temporary
             column_names : List : list of column names
-            appendoptimized: bool: Set to TRUE to create the table as an append-optimized table.
-                If FALSE, the table will be created as a regular heap-storage table.
-            orientation: str: Set to column for column-oriented storage, or row (the default) for
-                row-oriented storage. This option is only valid if appendoptimized=TRUE. Heap-storage
-                tables can only be row-oriented.
+            storage_params: dict: storage_parameter of gpdb, reference
+                https://docs.vmware.com/en/VMware-Tanzu-Greenplum/7/greenplum-database/GUID-ref_guide-sql_commands-CREATE_TABLE_AS.html
 
         Returns:
             DataFrame : :class:`DataFrame` represents the newly saved table

--- a/greenplumpython/dataframe.py
+++ b/greenplumpython/dataframe.py
@@ -936,8 +936,8 @@ class DataFrame:
         self._db.execute(
             f"""
             CREATE {'TEMP' if temp else ''} TABLE "{table_name}"
-            {storage_parameters if storage_params else ''}
             ({','.join(column_names)}) 
+            {storage_parameters if storage_params else ''}
             AS {self._build_full_query()}
             """,
             has_results=False,

--- a/greenplumpython/dataframe.py
+++ b/greenplumpython/dataframe.py
@@ -933,7 +933,7 @@ class DataFrame:
         self._db.execute(
             f"""
             CREATE {'TEMP' if temp else ''} TABLE "{table_name}"
-            ({','.join(column_names)}) 
+            ({','.join(column_names)})
             {storage_parameters if storage_params else ''}
             AS {self._build_full_query()}
             """,

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -327,6 +327,27 @@ def test_table_non_default_schema(db: gp.Database):
     assert len(list(pg_class)) > 0
 
 
+def test_table_with_ao(db: gp.Database):
+    columns = {"a": [1, 2, 3], "b": [1, 2, 3]}
+    t = db.create_dataframe(columns=columns)
+    # pass if no error
+    t.save_as(
+        "ao_dataframe", column_names=["a", "b"], temp=True, storage_params={"appendoptimized": True}
+    )
+
+
+def test_table_with_aoco(db: gp.Database):
+    columns = {"a": [1, 2, 3], "b": [1, 2, 3]}
+    t = db.create_dataframe(columns=columns)
+    # pass if no error
+    t.save_as(
+        "aoco_dataframe",
+        column_names=["a", "b"],
+        temp=True,
+        storage_params={"appendoptimized": True, "orientation": "column"},
+    )
+
+
 import pandas as pd
 
 

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -328,6 +328,16 @@ def test_table_non_default_schema(db: gp.Database):
 
 
 def test_table_with_ao(db: gp.Database):
+    result = db.execute("SELECT VERSION();")
+
+    if not result:
+        return
+
+    version: str = result[0]["version"]
+
+    if "Greenplum" not in version:
+        return
+
     columns = {"a": [1, 2, 3], "b": [1, 2, 3]}
     t = db.create_dataframe(columns=columns)
     # pass if no error
@@ -337,6 +347,16 @@ def test_table_with_ao(db: gp.Database):
 
 
 def test_table_with_aoco(db: gp.Database):
+    result = db.execute("SELECT VERSION();")
+
+    if not result:
+        return
+
+    version: str = result[0]["version"]
+
+    if "Greenplum" not in version:
+        return
+
     columns = {"a": [1, 2, 3], "b": [1, 2, 3]}
     t = db.create_dataframe(columns=columns)
     # pass if no error


### PR DESCRIPTION
Add 'with' storage_parameters options for save_as.

The AO table is more efficiency than heap for analytic usage, so `Greenplum Python` should have an option to create AO table.