### PR TITLE
Replace `= any()` with `EXISTS` for `in_()`

### DIFF
--- a/greenplumpython/expr.py
+++ b/greenplumpython/expr.py
@@ -495,7 +495,7 @@ class InExpr(Expr):
         container_name: str = "cte_" + uuid4().hex
         return (
             (
-                f"(EXISTS (SELECT FROM {self.other_dataframe.name}"
+                f'(EXISTS (SELECT FROM "{self.other_dataframe.name}"'
                 f" WHERE ({self._container.serialize()} = {self._item.serialize()})))"
             )
             if isinstance(self._container, Expr) and self.other_dataframe is not None

--- a/tests/test_binaryExpr.py
+++ b/tests/test_binaryExpr.py
@@ -198,6 +198,7 @@ def test_column_in_list(db: gp.Database):
     assert len(list(t[lambda t: t["x"].in_([1, 2, 3])])) == 3
     assert len(list(t[lambda t: ~t["x"].in_([1, 2, 3])])) == 7
 
+
 def test_column_in_none_values(db: gp.Database):
     rows = [(i,) for i in range(10)]
     t = db.create_dataframe(rows=rows, column_names=["x"])


### PR DESCRIPTION
Per the PostgreSQL guideline
https://wiki.postgresql.org/wiki/Don't_Do_This#Don.27t_use_NOT_IN,
`NOT IN` and `!= any()` has some intricate issues and should 
not be used in general.

Therefore, this patch replace the `= any()` with `EXISTS` in
implementation to
- make the semantic more clear , and
- make it easier for DB to generate efficient Anti-Join plans.