### PR TITLE
Set pycodestyle line length to 100

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -78,3 +78,6 @@ testpaths =
 [pydocstyle]
 # TODO: Enable docstyle check for all files
 match = .*(group|dataframe|config|op)\.py
+
+[pycodestyle]
+max-line-length = 100


### PR DESCRIPTION
pycodestyle line length lint is used by pylsp.
Set it to the same number as black in pyproject.toml.

pycodestyle doesn't suport pyproject.toml, see
https://github.com/PyCQA/pycodestyle/issues/813
