### PR TITLE
Remove redundant attributes and property

### DIFF
--- a/greenplumpython/builtins/functions.py
+++ b/greenplumpython/builtins/functions.py
@@ -8,8 +8,6 @@ from greenplumpython.group import DataFrameGroupingSet
 
 def count(
     arg: Optional[Any] = None,
-    group_by: Optional[DataFrameGroupingSet] = None,
-    db: Optional[Database] = None,
 ) -> FunctionExpr:
     """
     Count the number of rows or non-NULL values against a specified column or an entire table.
@@ -31,14 +29,12 @@ def count(
 
     """
     if arg is None:
-        return FunctionExpr(aggregate_function(name="count"), ("*",), group_by=group_by, db=db)
-    return FunctionExpr(aggregate_function(name="count"), (arg,), group_by=group_by, db=db)
+        return FunctionExpr(aggregate_function(name="count"), ("*",))
+    return FunctionExpr(aggregate_function(name="count"), (arg,))
 
 
 def min(
     arg: Any,
-    group_by: Optional[DataFrameGroupingSet] = None,
-    db: Optional[Database] = None,
 ) -> FunctionExpr:
     """
     Return the minimum value in a set of values.
@@ -59,13 +55,11 @@ def min(
             (1 row)
 
     """
-    return FunctionExpr(aggregate_function(name="min"), (arg,), group_by=group_by, db=db)
+    return FunctionExpr(aggregate_function(name="min"), (arg,))
 
 
 def max(
     arg: Any,
-    group_by: Optional[DataFrameGroupingSet] = None,
-    db: Optional[Database] = None,
 ) -> FunctionExpr:
     """
     Return the maximum value in a set of values.
@@ -86,13 +80,11 @@ def max(
             (1 row)
 
     """
-    return FunctionExpr(aggregate_function(name="max"), (arg,), group_by=group_by, db=db)
+    return FunctionExpr(aggregate_function(name="max"), (arg,))
 
 
 def avg(
     arg: Any,
-    group_by: Optional[DataFrameGroupingSet] = None,
-    db: Optional[Database] = None,
 ) -> FunctionExpr:
     """
     Calculate the average value of a set.
@@ -113,13 +105,11 @@ def avg(
             (1 row)
 
     """
-    return FunctionExpr(aggregate_function(name="avg"), (arg,), group_by=group_by, db=db)
+    return FunctionExpr(aggregate_function(name="avg"), (arg,))
 
 
 def sum(
     arg: Any,
-    group_by: Optional[DataFrameGroupingSet] = None,
-    db: Optional[Database] = None,
 ) -> FunctionExpr:
     """
     Calculate the sum of a set of values.
@@ -140,11 +130,11 @@ def sum(
             (1 row)
 
     """
-    return FunctionExpr(aggregate_function(name="sum"), (arg,), group_by=group_by, db=db)
+    return FunctionExpr(aggregate_function(name="sum"), (arg,))
 
 
 def generate_series(
-    start: Any, stop: Any, step: Optional[Any] = None, db: Optional[Database] = None
+    start: Any, stop: Any, step: Optional[Any] = None
 ) -> FunctionExpr:
     """
     Generate a series of values from :code:`start` to :code:`stop`, with a step size of :code:`step`.
@@ -174,4 +164,4 @@ def generate_series(
             (10 rows)
 
     """
-    return FunctionExpr(function(name="generate_series"), (start, stop, step), db=db)
+    return FunctionExpr(function(name="generate_series"), (start, stop, step))

--- a/greenplumpython/builtins/functions.py
+++ b/greenplumpython/builtins/functions.py
@@ -133,9 +133,7 @@ def sum(
     return FunctionExpr(aggregate_function(name="sum"), (arg,))
 
 
-def generate_series(
-    start: Any, stop: Any, step: Optional[Any] = None
-) -> FunctionExpr:
+def generate_series(start: Any, stop: Any, step: Optional[Any] = None) -> FunctionExpr:
     """
     Generate a series of values from :code:`start` to :code:`stop`, with a step size of :code:`step`.
 

--- a/greenplumpython/col.py
+++ b/greenplumpython/col.py
@@ -24,12 +24,11 @@ class ColumnField(Expr):
         column: "Column",
         field_name: str,
         dataframe: Optional["DataFrame"] = None,
-        db: Optional[Database] = None,
     ) -> None:
         self._field_name = field_name
         self._column = column
         self._dataframe = column._dataframe
-        super().__init__(dataframe, db)
+        super().__init__(dataframe)
 
     def _serialize(self) -> str:
         return f'({self._column._serialize()})."{self._field_name}"'

--- a/greenplumpython/col.py
+++ b/greenplumpython/col.py
@@ -23,12 +23,10 @@ class ColumnField(Expr):
         self,
         column: "Column",
         field_name: str,
-        dataframe: Optional["DataFrame"] = None,
     ) -> None:
         self._field_name = field_name
         self._column = column
-        self._dataframe = column._dataframe
-        super().__init__(dataframe)
+        super().__init__(column._dataframe)
 
     def _serialize(self) -> str:
         return f'({self._column._serialize()})."{self._field_name}"'

--- a/greenplumpython/db.py
+++ b/greenplumpython/db.py
@@ -213,7 +213,7 @@ class Database:
         for k, f in new_columns.items():
             v: Any = f()
             if isinstance(v, Expr):
-                assert v.dataframe is None, "New column should not depend on any dataframe."
+                assert v._dataframe is None, "New column should not depend on any dataframe."
             if isinstance(v, FunctionExpr):
                 v = v.bind(db=self)
             targets.append(f"{_serialize(v)} AS {k}")

--- a/greenplumpython/expr.py
+++ b/greenplumpython/expr.py
@@ -527,7 +527,7 @@ class Expr:
                 --------------
                 (5 rows)
         """
-        return InExpr(self, container, self._dataframe, self._db)
+        return InExpr(self, container, self._dataframe)
 
 
 from psycopg2.extensions import adapt  # type: ignore
@@ -660,7 +660,6 @@ class InExpr(Expr):
         item: "Expr",
         container: Union["Expr", List[Any]],
         dataframe: Optional["DataFrame"] = None,
-        db: Optional[Database] = None,
     ) -> None:
         # noqa: D107
         super().__init__(

--- a/greenplumpython/expr.py
+++ b/greenplumpython/expr.py
@@ -16,12 +16,11 @@ class Expr:
         self,
         dataframe: Optional["DataFrame"] = None,
         other_dataframe: Optional["DataFrame"] = None,
-        db: Optional[Database] = None,
     ) -> None:
         # noqa: D107
         self._dataframe = dataframe
         self._other_dataframe = other_dataframe
-        self._db = db if db is not None else (dataframe._db if dataframe is not None else None)
+        self._db = dataframe._db if dataframe is not None else None
 
     def __hash__(self) -> int:
         # noqa: D105
@@ -563,7 +562,6 @@ class BinaryExpr(Expr):
         operator: str,
         left: Any,
         right: Any,
-        db: Optional[Database] = None,
     ):
         # noqa: D107
         dataframe = left._dataframe if isinstance(left, Expr) else None
@@ -572,7 +570,7 @@ class BinaryExpr(Expr):
         other_dataframe = left._other_dataframe if isinstance(left, Expr) else None
         if other_dataframe is not None and isinstance(right, Expr):
             other_dataframe = right._other_dataframe
-        super().__init__(dataframe=dataframe, other_dataframe=other_dataframe, db=db)
+        super().__init__(dataframe=dataframe, other_dataframe=other_dataframe)
         self.operator = operator
         self.left = left
         self.right = right
@@ -583,7 +581,6 @@ class BinaryExpr(Expr):
         operator: str,
         left: "Expr",
         right: "Expr",
-        db: Optional[Database] = None,
     ):
         # noqa: D107
         ...
@@ -594,7 +591,6 @@ class BinaryExpr(Expr):
         operator: str,
         left: "Expr",
         right: int,
-        db: Optional[Database] = None,
     ):
         # noqa: D107
         ...
@@ -605,7 +601,6 @@ class BinaryExpr(Expr):
         operator: str,
         left: "Expr",
         right: str,
-        db: Optional[Database] = None,
     ):
         # noqa: D107
         ...
@@ -615,7 +610,6 @@ class BinaryExpr(Expr):
         operator: str,
         left: Any,
         right: Any,
-        db: Optional[Database] = None,
     ):
         # noqa: D107 D205 D400
         """
@@ -624,7 +618,7 @@ class BinaryExpr(Expr):
             left: Any : could be an :class:`Expr` or object in primitive types (int, str, etc)
             right: Any : could be an :class:`Expr` or object in primitive types (int, str, etc)
         """
-        self._init(operator, left, right, db)
+        self._init(operator, left, right)
 
     def _serialize(self) -> str:
         from greenplumpython.expr import _serialize
@@ -645,13 +639,12 @@ class UnaryExpr(Expr):
         self,
         operator: str,
         right: Any,
-        db: Optional[Database] = None,
     ):
         # noqa: D107
         dataframe, other_dataframe = (
             (right._dataframe, right._other_dataframe) if isinstance(right, Expr) else (None, None)
         )
-        super().__init__(dataframe=dataframe, other_dataframe=other_dataframe, db=db)
+        super().__init__(dataframe=dataframe, other_dataframe=other_dataframe)
         self.operator = operator
         self.right = right
 
@@ -673,7 +666,6 @@ class InExpr(Expr):
         super().__init__(
             dataframe,
             other_dataframe=container._dataframe if isinstance(container, Expr) else None,
-            db=db,
         )
         self._item = item
         self._container = container

--- a/greenplumpython/func.py
+++ b/greenplumpython/func.py
@@ -40,12 +40,12 @@ class FunctionExpr(Expr):
     ) -> None:
         # noqa D400
         if dataframe is None and group_by is not None:
-            dataframe = group_by.dataframe
+            dataframe = group_by._dataframe
         for arg in args:
-            if isinstance(arg, Expr) and arg.dataframe is not None:
+            if isinstance(arg, Expr) and arg._dataframe is not None:
                 if dataframe is None:
-                    dataframe = arg.dataframe
-                elif dataframe.name != arg.dataframe.name:
+                    dataframe = arg._dataframe
+                elif dataframe._name != arg._dataframe._name:
                     raise Exception("Cannot pass arguments from more than one dataframes")
         super().__init__(dataframe=dataframe, db=db)
         self._func = func
@@ -80,7 +80,7 @@ class FunctionExpr(Expr):
             if any(self._args)
             else ""
         )
-        schema, func_name = self._function.qualified_name_tuple
+        schema, func_name = self._function._qualified_name
         qualified_name = f'"{schema}"."{func_name}"' if schema is not None else f'"{func_name}"'
         return f"{qualified_name}({distinct} {args_string})"
 
@@ -96,8 +96,8 @@ class FunctionExpr(Expr):
             expand and column_name is not None
         ), "Cannot assign single column name when expanding multi-valued results."
         self._function._create_in_db(self._db)
-        if self.dataframe is not None:
-            schema, df_name = self.dataframe.qualified_name_tuple
+        if self._dataframe is not None:
+            schema, df_name = self._dataframe._qualified_name
             df_qualified_name = f'"{schema}"."{df_name}"' if schema is not None else f'"{df_name}"'
             from_clause = f"FROM {df_qualified_name}"
         else:
@@ -105,7 +105,7 @@ class FunctionExpr(Expr):
         group_by_clause = self._group_by._clause() if self._group_by is not None else ""
         if expand and column_name is None:
             column_name = "func_" + uuid4().hex
-        parents = [self.dataframe] if self.dataframe is not None else []
+        parents = [self._dataframe] if self._dataframe is not None else []
         grouping_col_names = self._group_by._flatten() if self._group_by is not None else None
         # FIXME: The names of GROUP BY exprs can collide with names of fields in
         # the comosite type, making the column names of the resulting dataframe not
@@ -151,12 +151,12 @@ class FunctionExpr(Expr):
             if not expand
             else f"({column_name}).*"
             if rebased_grouping_cols is None or len(rebased_grouping_cols) == 0
-            else f"({orig_func_dataframe.name}).*"
+            else f"({orig_func_dataframe._name}).*"
             if not expand
             else f"{','.join(rebased_grouping_cols)}, ({column_name}).*"
         )
 
-        schema, df_name = orig_func_dataframe.qualified_name_tuple
+        schema, df_name = orig_func_dataframe._qualified_name
         orig_df_qualified_name = f'"{schema}"."{df_name}"' if schema is not None else f'"{df_name}"'
         return DataFrame(
             f"SELECT {str(results)} FROM {orig_df_qualified_name}",
@@ -202,7 +202,7 @@ class ArrayFunctionExpr(FunctionExpr):
                     s = _serialize(self._args[i])
                 args_string_list.append(s)
             args_string = ",".join(args_string_list)
-        schema, func_name = self._function.qualified_name_tuple
+        schema, func_name = self._function._qualified_name
         qualified_name = f'"{schema}"."{func_name}"' if schema is not None else f'"{func_name}"'
         return f"{qualified_name}({args_string})"
 
@@ -240,7 +240,7 @@ class _AbstractFunction:
         self._schema = "pg_temp" if wrapped_func is not None else None if schema is None else schema
 
     @property
-    def qualified_name_tuple(self) -> Tuple[str, str]:
+    def _qualified_name(self) -> Tuple[Optional[str], str]:
         return self._schema, self._name
 
     def _create_in_db(self, _: Database) -> None:
@@ -320,7 +320,7 @@ class NormalFunction(_AbstractFunction):
             )
             return_type = to_pg_type(func_sig.return_annotation, db=db, for_return=True)
             func_pickled: bytes = dill.dumps(self._wrapped_func)
-            schema, func_name = self.qualified_name_tuple
+            schema, func_name = self._qualified_name
             qualified_name = f'"{schema}"."{func_name}"' if schema is not None else f'"{func_name}"'
             # Modify the AST of the wrapped function to minify dependency: (1-3)
             # 1. Apply random renaming to avoid name conflict. (TODO: Support
@@ -450,7 +450,7 @@ class AggregateFunction(_AbstractFunction):
     @property
     def transition_function(self) -> NormalFunction:
         """Return the transition function of the aggregate function."""
-        schema, func_name = self.qualified_name_tuple
+        schema, func_name = self._qualified_name
         qualified_name = f'"{schema}"."{func_name}"' if schema is not None else f'"{func_name}"'
         assert (
             self._transition_func is not None
@@ -472,11 +472,11 @@ class AggregateFunction(_AbstractFunction):
             args_string = ",".join(
                 [f"{param.name} {to_pg_type(param.annotation, db=db)}" for param in param_list]
             )
-            agg_schema, agg_name = self.qualified_name_tuple
+            agg_schema, agg_name = self._qualified_name
             agg_qualified_name = (
                 f'"{agg_schema}"."{agg_name}"' if agg_schema is not None else f'"{agg_name}"'
             )
-            sfunc_schema, sfunc_name = self.transition_function.qualified_name_tuple
+            sfunc_schema, sfunc_name = self.transition_function._qualified_name
             sfunc_qualified_name = (
                 f'"{sfunc_schema}"."{sfunc_name}"'
                 if sfunc_schema is not None

--- a/greenplumpython/func.py
+++ b/greenplumpython/func.py
@@ -67,7 +67,16 @@ class FunctionExpr(Expr):
             dataframe=dataframe,
             distinct=self._distinct,
         )
-        f._db = db if db is not None else self._db
+        f._db = (
+            db
+            if db is not None
+            else dataframe._db
+            if dataframe is not None
+            else group_by._dataframe._db
+            if group_by is not None
+            else self._db
+        )
+        assert f._db is not None
         return f
 
     def _serialize(self) -> str:

--- a/greenplumpython/func.py
+++ b/greenplumpython/func.py
@@ -52,7 +52,6 @@ class FunctionExpr(Expr):
         self._group_by = group_by
         self._distinct = distinct
 
-
     def bind(
         self,
         group_by: Optional[DataFrameGroupingSet] = None,

--- a/greenplumpython/group.py
+++ b/greenplumpython/group.py
@@ -157,13 +157,15 @@ class DataFrameGroupingSet:
 
         targets: List[str] = self._flatten()
         for k, f in new_columns.items():
-            v: Any = f(self.dataframe).bind(group_by=self)
-            if isinstance(v, Expr) and not (v.dataframe is None or v.dataframe == self.dataframe):
+            v: Any = f(self._dataframe).bind(group_by=self)
+            if isinstance(v, Expr) and not (
+                v._dataframe is None or v._dataframe == self._dataframe
+            ):
                 raise Exception("Newly included columns must be based on the current dataframe")
             targets.append(f"{_serialize(v)} AS {k}")
         return DataFrame(
-            f"SELECT {','.join(targets)} FROM {self.dataframe.name} {self._clause()}",
-            parents=[self.dataframe],
+            f"SELECT {','.join(targets)} FROM {self._dataframe._name} {self._clause()}",
+            parents=[self._dataframe],
         )
 
     def union(
@@ -222,16 +224,6 @@ class DataFrameGroupingSet:
                 if item not in item_list:
                     item_list.append(item)
         return item_list
-
-    @property
-    def dataframe(self) -> "DataFrame":
-        """
-        Return the source :class:`~dataframe.DataFrame` associated with grouping set.
-
-        Returns:
-            GreenplumPython DataFrame
-        """
-        return self._dataframe
 
     def _clause(self) -> str:
         # noqa: D400

--- a/greenplumpython/order.py
+++ b/greenplumpython/order.py
@@ -113,7 +113,7 @@ class DataFrameOrdering:
             else rows.stop - rows.start
         )
         return DataFrame(
-            f"SELECT * FROM {self._dataframe.name} {self._clause()} LIMIT {limit} {offset_clause}",
+            f"SELECT * FROM {self._dataframe._name} {self._clause()} LIMIT {limit} {offset_clause}",
             parents=[self._dataframe],
         )
 

--- a/greenplumpython/type.py
+++ b/greenplumpython/type.py
@@ -33,7 +33,6 @@ class TypeCast(Expr):
         obj: object,
         type_name: str,
         schema: Optional[str] = None,
-        db: Optional[Database] = None,
     ) -> None:
         # noqa: D205 D400
         """
@@ -42,7 +41,7 @@ class TypeCast(Expr):
             type_name : str : name of type which object will be cast
         """
         dataframe = obj._dataframe if isinstance(obj, Expr) else None
-        super().__init__(dataframe, db=db)
+        super().__init__(dataframe)
         self._obj = obj
         self._type_name = type_name
         self._schema = schema

--- a/greenplumpython/type.py
+++ b/greenplumpython/type.py
@@ -41,7 +41,7 @@ class TypeCast(Expr):
             obj: object : which will be applied type casting
             type_name : str : name of type which object will be cast
         """
-        dataframe = obj.dataframe if isinstance(obj, Expr) else None
+        dataframe = obj._dataframe if isinstance(obj, Expr) else None
         super().__init__(dataframe, db=db)
         self._obj = obj
         self._type_name = type_name
@@ -49,12 +49,12 @@ class TypeCast(Expr):
 
     def _serialize(self) -> str:
         obj_str = _serialize(self._obj)
-        schema, type_name = self.qualified_name_tuple
+        schema, type_name = self._qualified_name
         qualified_name = f'"{schema}"."{type_name}"' if schema is not None else f'"{type_name}"'
         return f"({obj_str}::{qualified_name})"
 
     @property
-    def qualified_name_tuple(self) -> Tuple[str, str]:
+    def _qualified_name(self) -> Tuple[Optional[str], str]:
         """
         Return the schema name and name of :class:`~type.TypeCast`.
 
@@ -136,12 +136,7 @@ class Type:
         return TypeCast(obj, self._name, self._schema)
 
     @property
-    def name(self) -> str:
-        """Get the name of this :class:`Type`."""
-        return self._name
-
-    @property
-    def qualified_name_tuple(self) -> Tuple[str, str]:
+    def _qualified_name(self) -> Tuple[Optional[str], str]:
         """
         Return the schema name and name of :class:`~type.Type`.
 
@@ -212,7 +207,7 @@ def to_pg_type(
             type_name = "type_" + uuid4().hex
             _defined_types[annotation] = Type(name=type_name, annotation=annotation)
         _defined_types[annotation]._create_in_db(db)
-        schema, type_name = _defined_types[annotation].qualified_name_tuple
+        schema, type_name = _defined_types[annotation]._qualified_name
         type_qualified_name = (
             f'"{schema}"."{type_name}"' if schema is not None else f'"{type_name}"'
         )

--- a/tests/test_binaryExpr.py
+++ b/tests/test_binaryExpr.py
@@ -63,7 +63,7 @@ def test_expr_bin_equal_bool(db: gp.Database):
 @pytest.fixture
 def dataframe_num(db: gp.Database):
     t = db.assign(id=lambda: generate_series(0, 9))
-    assert t.db is not None
+    assert t._db is not None
     return t
 
 

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -16,7 +16,7 @@ def dataframe(db: gp.Database):
 
 def test_expr_column_name(db: gp.Database, dataframe: gp.DataFrame):
     c = gp.col.Column("id", dataframe)
-    assert c.name == "id"
+    assert c._name == "id"
 
 
 def test_expr_column_str(db: gp.Database, dataframe: gp.DataFrame):
@@ -26,7 +26,7 @@ def test_expr_column_str(db: gp.Database, dataframe: gp.DataFrame):
 
 def test_expr_column_str_in_query(db: gp.Database, dataframe: gp.DataFrame):
     c = gp.col.Column("id", dataframe)
-    query = "select " + str(c) + " from " + c.dataframe.name
+    query = "select " + str(c) + " from " + c._dataframe._name
     tr = gp.DataFrame(query=query, db=db)
     for row in tr:
         assert list(row.keys()) == ["id"]

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -37,7 +37,7 @@ def test_dataframe_getitem_str(db: gp.Database):
     rows = [(1,), (2,), (3,)]
     t = db.create_dataframe(rows=rows, column_names=["id"])
     c = t["id"]
-    assert str(c) == f'"{t.name}"."id"'
+    assert str(c) == f'"{t._name}"."id"'
 
 
 def test_dataframe_getitem_sub_columns(db: gp.Database):

--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -636,13 +636,13 @@ def test_create_func_same_name(db: gp.Database):
     def dup_name(a: int, b: int) -> int:
         return a + b
 
-    _, func_name = dup_name.qualified_name_tuple
+    _, func_name = dup_name._qualified_name
 
     @gp.create_function
     def dup_name(a: int, b: int) -> int:
         return a + 1
 
-    _, new_func_name = dup_name.qualified_name_tuple
+    _, new_func_name = dup_name._qualified_name
 
     assert func_name != new_func_name
 

--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -134,7 +134,7 @@ def test_func_on_more_than_one_dataframe(db: gp.Database):
     t1 = db.create_dataframe(rows=rows, column_names=["i"])
     t2 = db.create_dataframe(rows=rows, column_names=["i"])
     with pytest.raises(Exception) as exc_info:
-        div(t1["i"], t2["i"], db=db)
+        div(t1["i"], t2["i"])
     # FIXME: Create more specific exception classes and remove this
     assert "Cannot pass arguments from more than one dataframes" == str(exc_info.value)
 


### PR DESCRIPTION
This patch removes redundant private `@property`. 
And fix type error of `_qualified_name`'s return type.
This patch removes also redundant attributes in class constructors
and methods.