### PR TITLE
Fix doc typo

### DIFF
--- a/doc/source/notebooks/basic.ipynb
+++ b/doc/source/notebooks/basic.ipynb
@@ -18,7 +18,7 @@
                 "    FROM generate_series(0,9) AS n;\n",
                 "    ```\n",
                 "\n",
-                "To create this table, if in a shell environment, [`psql`](https://www.postgresql.org/docs/current/app-psql.html) can be used.\n",
+                "To create this table, if in a shell environment, [psql](https://www.postgresql.org/docs/current/app-psql.html) can be used.\n",
                 "\n",
                 "Or, inside a Jupyter Notebook, the SQL command can be executed directly in cells with [ipython-sql](https://pypi.org/project/ipython-sql/), as shown below.\n",
                 "\n",


### PR DESCRIPTION
hyperlinks cannot be surrounded by backticks('`').
