### PR TITLE
Fix schema problem for advanced scenarios

### DIFF
--- a/greenplumpython/col.py
+++ b/greenplumpython/col.py
@@ -47,10 +47,10 @@ class Column(Expr):
     def _serialize(self) -> str:
         assert self._dataframe is not None
         # Quote both dataframe name and column name to avoid SQL injection.
-        schema, df_name = self._dataframe._qualified_name
-        df_qualified_name = f'"{schema}"."{df_name}"' if schema is not None else f'"{df_name}"'
         return (
-            f'{df_qualified_name}."{self._name}"' if self._name != "*" else f"{df_qualified_name}.*"
+            f'{self._dataframe._qualified_name_str}."{self._name}"'
+            if self._name != "*"
+            else f"{self._dataframe._qualified_name_str}.*"
         )
 
     def __getitem__(self, field_name: str) -> ColumnField:

--- a/greenplumpython/expr.py
+++ b/greenplumpython/expr.py
@@ -671,12 +671,8 @@ class InExpr(Expr):
         # when combining with `～` (bitwise not) operator.
         container_name: str = "cte_" + uuid4().hex
         if isinstance(self._container, Expr) and self._other_dataframe is not None:
-            other_schema, other_name = self._other_dataframe._qualified_name
-            qualified_name = (
-                f'"{other_name}"' if other_schema is None else f'"{other_schema}"."{other_name}"'
-            )
             return (
-                f"(EXISTS (SELECT FROM {qualified_name}"
+                f"(EXISTS (SELECT FROM {self._other_dataframe._qualified_name_str}"
                 f" WHERE ({self._container._serialize()} = {self._item._serialize()})))"
             )
 

--- a/greenplumpython/func.py
+++ b/greenplumpython/func.py
@@ -90,9 +90,7 @@ class FunctionExpr(Expr):
             if any(self._args)
             else ""
         )
-        schema, func_name = self._function._qualified_name
-        qualified_name = f'"{schema}"."{func_name}"' if schema is not None else f'"{func_name}"'
-        return f"{qualified_name}({distinct} {args_string})"
+        return f"{self._function._qualified_name_str}({distinct} {args_string})"
 
     def apply(self, expand: bool = False, column_name: Optional[str] = None) -> DataFrame:
         # noqa D400
@@ -106,12 +104,9 @@ class FunctionExpr(Expr):
             expand and column_name is not None
         ), "Cannot assign single column name when expanding multi-valued results."
         self._function._create_in_db(self._db)
-        if self._dataframe is not None:
-            schema, df_name = self._dataframe._qualified_name
-            df_qualified_name = f'"{schema}"."{df_name}"' if schema is not None else f'"{df_name}"'
-            from_clause = f"FROM {df_qualified_name}"
-        else:
-            from_clause = ""
+        from_clause = (
+            f"FROM {self._dataframe._qualified_name_str}" if self._dataframe is not None else ""
+        )
         group_by_clause = self._group_by._clause() if self._group_by is not None else ""
         if expand and column_name is None:
             column_name = "func_" + uuid4().hex
@@ -166,10 +161,8 @@ class FunctionExpr(Expr):
             else f"{','.join(rebased_grouping_cols)}, ({column_name}).*"
         )
 
-        schema, df_name = orig_func_dataframe._qualified_name
-        orig_df_qualified_name = f'"{schema}"."{df_name}"' if schema is not None else f'"{df_name}"'
         return DataFrame(
-            f"SELECT {str(results)} FROM {orig_df_qualified_name}",
+            f"SELECT {str(results)} FROM {orig_func_dataframe._qualified_name_str}",
             db=self._db,
             parents=[orig_func_dataframe],
         )
@@ -212,9 +205,7 @@ class ArrayFunctionExpr(FunctionExpr):
                     s = _serialize(self._args[i])
                 args_string_list.append(s)
             args_string = ",".join(args_string_list)
-        schema, func_name = self._function._qualified_name
-        qualified_name = f'"{schema}"."{func_name}"' if schema is not None else f'"{func_name}"'
-        return f"{qualified_name}({args_string})"
+        return f"{self._function._qualified_name_str}({args_string})"
 
     def bind(
         self,
@@ -249,6 +240,9 @@ class _AbstractFunction:
         self._name = "func_" + uuid4().hex if wrapped_func is not None else name
         assert self._name is not None
         self._schema = "pg_temp" if wrapped_func is not None else None if schema is None else schema
+        self._qualified_name_str = (
+            f'"{self._name}"' if self._schema is None else f'"{self._schema}"."{self._name}"'
+        )
 
     @property
     def _qualified_name(self) -> Tuple[Optional[str], str]:
@@ -331,8 +325,7 @@ class NormalFunction(_AbstractFunction):
             )
             return_type = to_pg_type(func_sig.return_annotation, db=db, for_return=True)
             func_pickled: bytes = dill.dumps(self._wrapped_func)
-            schema, func_name = self._qualified_name
-            qualified_name = f'"{schema}"."{func_name}"' if schema is not None else f'"{func_name}"'
+            _, func_name = self._qualified_name
             # Modify the AST of the wrapped function to minify dependency: (1-3)
             # 1. Apply random renaming to avoid name conflict. (TODO: Support
             #    calling another UDF in the current UDF directly.)
@@ -354,7 +347,7 @@ class NormalFunction(_AbstractFunction):
             assert (
                 db._execute(
                     (
-                        f"CREATE FUNCTION {qualified_name} ({func_args}) "
+                        f"CREATE FUNCTION {self._qualified_name_str} ({func_args}) "
                         f"RETURNS {return_type} "
                         f"AS $$\n"
                         f"try:\n"
@@ -460,11 +453,9 @@ class AggregateFunction(_AbstractFunction):
     @property
     def transition_function(self) -> NormalFunction:
         """Return the transition function of the aggregate function."""
-        schema, func_name = self._qualified_name
-        qualified_name = f'"{schema}"."{func_name}"' if schema is not None else f'"{func_name}"'
         assert (
             self._transition_func is not None
-        ), f"Transition function of the aggregate function {qualified_name} is unknown."
+        ), f"Transition function of the aggregate function {self._qualified_name_str} is unknown."
         return self._transition_func
 
     def _create_in_db(self, db: Database) -> None:
@@ -482,21 +473,11 @@ class AggregateFunction(_AbstractFunction):
             args_string = ",".join(
                 [f"{param.name} {to_pg_type(param.annotation, db=db)}" for param in param_list]
             )
-            agg_schema, agg_name = self._qualified_name
-            agg_qualified_name = (
-                f'"{agg_schema}"."{agg_name}"' if agg_schema is not None else f'"{agg_name}"'
-            )
-            sfunc_schema, sfunc_name = self.transition_function._qualified_name
-            sfunc_qualified_name = (
-                f'"{sfunc_schema}"."{sfunc_name}"'
-                if sfunc_schema is not None
-                else f'"{sfunc_name}"'
-            )
             # -- Creation of UDA in Greenplum
             db._execute(
                 (
-                    f"CREATE AGGREGATE {agg_qualified_name} ({args_string}) (\n"
-                    f"    SFUNC = {sfunc_qualified_name},\n"
+                    f"CREATE AGGREGATE {self._qualified_name_str} ({args_string}) (\n"
+                    f"    SFUNC = {self.transition_function._qualified_name_str},\n"
                     f"    STYPE = {to_pg_type(state_param.annotation, db=db)}\n"
                     f");\n"
                 ),

--- a/greenplumpython/group.py
+++ b/greenplumpython/group.py
@@ -163,10 +163,8 @@ class DataFrameGroupingSet:
             ):
                 raise Exception("Newly included columns must be based on the current dataframe")
             targets.append(f"{_serialize(v)} AS {k}")
-        schema, name = self._dataframe._qualified_name
-        qualified_name = f'"{name}"' if schema is None else f'"{schema}"."{name}"'
         return DataFrame(
-            f"SELECT {','.join(targets)} FROM {qualified_name} {self._clause()}",
+            f"SELECT {','.join(targets)} FROM {self._dataframe._qualified_name_str} {self._clause()}",
             parents=[self._dataframe],
         )
 

--- a/greenplumpython/group.py
+++ b/greenplumpython/group.py
@@ -163,8 +163,10 @@ class DataFrameGroupingSet:
             ):
                 raise Exception("Newly included columns must be based on the current dataframe")
             targets.append(f"{_serialize(v)} AS {k}")
+        schema, name = self._dataframe._qualified_name
+        qualified_name = f'"{name}"' if schema is None else f'"{schema}"."{name}"'
         return DataFrame(
-            f"SELECT {','.join(targets)} FROM {self._dataframe._name} {self._clause()}",
+            f"SELECT {','.join(targets)} FROM {qualified_name} {self._clause()}",
             parents=[self._dataframe],
         )
 

--- a/greenplumpython/order.py
+++ b/greenplumpython/order.py
@@ -114,10 +114,8 @@ class DataFrameOrdering:
             if rows.start is None
             else rows.stop - rows.start
         )
-        schema, name = self._dataframe._qualified_name
-        qualified_name = f'"{name}"' if schema is None else f'"{schema}"."{name}"'
         return DataFrame(
-            f"SELECT * FROM {qualified_name} {self._clause()} LIMIT {limit} {offset_clause}",
+            f"SELECT * FROM {self._dataframe._qualified_name_str} {self._clause()} LIMIT {limit} {offset_clause}",
             parents=[self._dataframe],
         )
 

--- a/greenplumpython/order.py
+++ b/greenplumpython/order.py
@@ -114,8 +114,10 @@ class DataFrameOrdering:
             if rows.start is None
             else rows.stop - rows.start
         )
+        schema, name = self._dataframe._qualified_name
+        qualified_name = f'"{name}"' if schema is None else f'"{schema}"."{name}"'
         return DataFrame(
-            f"SELECT * FROM {self._dataframe._name} {self._clause()} LIMIT {limit} {offset_clause}",
+            f"SELECT * FROM {qualified_name} {self._clause()} LIMIT {limit} {offset_clause}",
             parents=[self._dataframe],
         )
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -52,7 +52,13 @@ def test_schema_self_join_on(db: gp.Database, t: gp.DataFrame):
     assert len(list(ret)) == 10
 
 
-# TODO: test_self_join_cond after merged PR#182
+def test_schema_self_join_cond(db: gp.Database, t: gp.DataFrame):
+    ret: gp.DataFrame = t.join(
+        t,
+        cond=lambda s, o: s["id"] == o["id"],
+        other_columns={"id": "id_1"},
+    )
+    assert len(list(ret)) == 10
 
 
 def test_schema_distinct(db: gp.Database, t: gp.DataFrame):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,75 @@
+from os import environ
+
+import pytest
+
+import greenplumpython as gp
+from greenplumpython.builtins.functions import generate_series
+from tests import db
+
+
+@pytest.fixture
+def t(db: gp.Database):
+    db._execute("DROP TABLE IF EXISTS tets.test_t", has_results=False)
+    db._execute("DROP TABLE IF EXISTS tets.test_t2", has_results=False)
+    db.assign(id=lambda: generate_series(0, 9)).save_as(
+        table_name="test_t", column_names=["id"], schema="test"
+    )
+    t = db.create_dataframe(table_name="test_t", schema="test")
+    return t
+
+
+def test_schema_get_slice(db: gp.Database, t: gp.DataFrame):
+    assert len(list(t[2:5])) == 3
+
+
+def test_schema_get_columns(db: gp.Database, t: gp.DataFrame):
+    assert len(list(t[["id"]])) == 10
+
+
+def test_schema_get_cond(db: gp.Database, t: gp.DataFrame):
+    assert len(list(t[lambda t: t["id"] < 5])) == 5
+
+
+def test_schema_join(db: gp.Database, t: gp.DataFrame):
+    db.assign(id=lambda: generate_series(0, 9)).save_as(
+        table_name="test_t2", column_names=["id"], schema="test"
+    )
+    t2 = db.create_dataframe(table_name="test_t2", schema="test")
+    ret: gp.DataFrame = t.join(
+        t2,
+        cond=lambda s, o: s["id"] == o["id"],
+        other_columns={"id": "id_2"},
+    )
+    assert len(list(ret)) == 10
+
+
+def test_schema_self_join_on(db: gp.Database, t: gp.DataFrame):
+    ret: gp.DataFrame = t.join(
+        t,
+        on=["id"],
+        other_columns={"id": "id_1"},
+    )
+    assert len(list(ret)) == 10
+
+
+# TODO: test_self_join_cond after merged PR#182
+
+
+def test_schema_distinct(db: gp.Database, t: gp.DataFrame):
+    result = list(t.distinct_on("id"))
+    assert len(result) == 10
+
+
+def test_schema_in(db: gp.Database, t: gp.DataFrame):
+    assert len(list(t[lambda t: t["id"].in_([1, 2, 3])])) == 3
+
+
+def test_schema_group_assign(db: gp.Database, t: gp.DataFrame):
+    ret = t.assign(is_even=lambda t: t["id"] % 2 == 0)
+    count = gp.aggregate_function("count")
+    results = ret.group_by("is_even").assign(count=lambda row: count(row["*"]))
+    assert len(list(results)) == 2
+
+
+def test_schema_order(db: gp.Database, t: gp.DataFrame):
+    assert len(list(t.order_by("id")[:])) == 10


### PR DESCRIPTION
Previously, [PR#131](https://github.com/greenplum-db/GreenplumPython/pull/131) and [PR#156](https://github.com/greenplum-db/GreenplumPython/pull/156) fixed most of problem when table in non-default schema.
This patch fixes problem in non-default schema for more advanced scenarios:
- Get item
- Join
- Group by
- Order by
- Contain 

Also adds file `test_schema` to cover more comprehensively scenarios.