### PR TITLE
Make Row a subclass of abc.Mapping

### DIFF
--- a/greenplumpython/row.py
+++ b/greenplumpython/row.py
@@ -1,14 +1,20 @@
 """
 This module creates a Python object :class:`~row.Row` for GreenplumPython DataFrame iteration.
 """
+from collections import abc
 from typing import Any, Dict, Iterable, List, Tuple, Union
 
 
-class Row:
+class Row(abc.Mapping[str, Union[Any, List[Any]]]):
     """
     Represents a row of :class:`~dataframe.DataFrame`.
 
     A :class:`~row.Row` is conceptually an immutable :class:`dict`.
+
+    Row is a subclass of :code:`abc.Mapping` and it must implement all the
+    methods in the latter class, as specified in
+    `the document <https://docs.python.org/3/library/collections.abc.html>`_
+    of the built-in Abstract Base Class (ABC) module.
     """
 
     def __init__(self, contents: Dict[str, Union[Any, List[Any]]]):
@@ -63,3 +69,9 @@ class Row:
 
     def items(self) -> Iterable[Tuple[str, Any]]:
         return self._contents.items()
+
+    def __eq__(self, other: "Row") -> bool:
+        return self._contents == other._contents
+
+    def __ne__(self, other: "Row") -> bool:
+        return self._contents != other._contents

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -379,10 +379,10 @@ import pandas as pd
 
 
 def test_table_to_pandas_dataframe(db: gp.Database):
-    pg_class = db.create_dataframe(table_name="pg_class", schema="pg_catalog")
-
-    df = pd.DataFrame.from_records(iter(pg_class))
-    assert len(df) > 0
+    data = {"num": [1, 2, 3], "text": ["x", "y", "z"]}
+    df = pd.DataFrame(data)
+    df_from_gp = pd.DataFrame.from_records(iter(db.create_dataframe(columns=data)))
+    assert df.equals(df_from_gp)
 
 
 def test_table_from_pandas_dataframe(db: gp.Database):


### PR DESCRIPTION
Conceptually, a Row is an immutable `dict` in Python and we previously added many methods to make this claim true. However, pandas requires stating its base class explicitly. Otherwise it will fail to treat it as an immutable `dict`.

To fix this issue, this patch sets the base class of Row to abc.Mapping explicitly and add other methods required by abc.Mapping