### PR TITLE
Remove `--user` in install tuto

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@ GreenplumPython provides a [pandas](https://pandas.pydata.org/)-like DataFrame A
 
 ## Installation
 
-To install the latest development version, do
+To install the latest development version as non root user, do
 
 ```bash
-pip3 install --user git+https://github.com/greenplum-db/GreenplumPython
+pip3 install git+https://github.com/greenplum-db/GreenplumPython
 ```
 
-To install the latest released version, do
+To install the latest released version as non root user, do
 
 ```bash
-pip3 install --user greenplum-python
+pip3 install greenplum-python
 ```
 
 ## Documentation

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -14,11 +14,11 @@ You can install latest release of the **GreenplumPython** library with pip3:
 
     pip3 install greenplum-python
 
-To install the latest development version, do
+To install the latest development version as non root user, do
 
 .. code-block:: bash
 
-    pip3 install --user git+https://github.com/greenplum-db/GreenplumPython
+    pip3 install git+https://github.com/greenplum-db/GreenplumPython
 
 GreenplumPython requires `plpython3 <https://docs.vmware.com/en/VMware-Tanzu-Greenplum/6/greenplum-database/GUID-analytics-pl_python.html>`_ 
 extension to be installed on Greenplum/Postgres.


### PR DESCRIPTION
Anaconda recommends do not use pip with the `--user` argument 
in `Conda` environment, avoid all “users” installs. 
To be more clear, this patch removes `--user` argument  in doc
and precise installation need to be with non root user.