### PR TITLE
Fix problem when args having no db when applying

### DIFF
--- a/greenplumpython/func.py
+++ b/greenplumpython/func.py
@@ -85,6 +85,9 @@ class FunctionExpr(Expr):
         """:meta private:"""
         self._function._create_in_db(self._db)
         distinct = "DISTINCT" if self._distinct else ""
+        for arg in self._args:
+          if isinstance(arg, Expr):
+            arg._db = self._db
         args_string = (
             ",".join([_serialize(arg) for arg in self._args if arg is not None])
             if any(self._args)

--- a/greenplumpython/func.py
+++ b/greenplumpython/func.py
@@ -86,8 +86,8 @@ class FunctionExpr(Expr):
         self._function._create_in_db(self._db)
         distinct = "DISTINCT" if self._distinct else ""
         for arg in self._args:
-          if isinstance(arg, Expr):
-            arg._db = self._db
+            if isinstance(arg, Expr):
+                arg._db = self._db
         args_string = (
             ",".join([_serialize(arg) for arg in self._args if arg is not None])
             if any(self._args)

--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -802,10 +802,12 @@ def test_func_non_default_schema(db: gp.Database):
 
 def test_func_nested_create(db: gp.Database):
     @gp.create_function
-    def add_one(x: int) -> int: return x + 1
+    def add_one(x: int) -> int:
+        return x + 1
 
     @gp.create_function
-    def add_two(x: int) -> int: return x + 2
+    def add_two(x: int) -> int:
+        return x + 2
 
     result = db.apply(lambda: add_two(add_one(1)), column_name="val")
     for row in result:

--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -798,3 +798,15 @@ def test_func_non_default_schema(db: gp.Database):
     # -- WITH APPLY FUNC
     results2 = series.apply(lambda nums: abs(nums["id"]))
     assert sorted([row["abs"] for row in results2]) == list(range(1, 11))
+
+
+def test_func_nested_create(db: gp.Database):
+    @gp.create_function
+    def add_one(x: int) -> int: return x + 1
+
+    @gp.create_function
+    def add_two(x: int) -> int: return x + 2
+
+    result = db.apply(lambda: add_two(add_one(1)), column_name="val")
+    for row in result:
+        assert row["val"] == 1 + 1 + 2


### PR DESCRIPTION
Fix bugs when applying following functions: give constant to
a sub-functions: `Database is required to create type`.
```
df.assign(
    func2=lambda t: func2(func1("a plane"))
)
```