### PR TITLE
Fix select slice with [:]

### DIFF
--- a/greenplumpython/dataframe.py
+++ b/greenplumpython/dataframe.py
@@ -26,6 +26,7 @@ in that:
   <https://www.postgresql.org/docs/current/sql-refreshmaterializedview.html>`_ for syncing updates.
 """
 import json
+import sys
 from collections import abc
 from functools import partialmethod, singledispatchmethod
 from typing import (
@@ -110,12 +111,14 @@ class DataFrame:
             raise NotImplementedError()
         offset_clause = "" if rows.start is None else f"OFFSET {rows.start}"
         limit_clause = (
-            ""
+            sys.maxsize
             if rows.stop is None
-            else f"LIMIT {rows.stop if rows.start is None else rows.stop - rows.start}"
+            else rows.stop
+            if rows.start is None
+            else rows.stop - rows.start
         )
         return DataFrame(
-            f"SELECT * FROM {self._name} {limit_clause} {offset_clause}",
+            f"SELECT * FROM {self._name} LIMIT {limit_clause} {offset_clause}",
             parents=[self],
         )
 

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -62,6 +62,12 @@ def test_dataframe_getitem_slice_off_limit(db: gp.Database, t: gp.DataFrame):
     assert len(list(t[2:5])) == 3
 
 
+def test_dataframe_getitem_slice_off_limit(db: gp.Database, t: gp.DataFrame):
+    query = t[:]._build_full_query()
+    assert len(list(t[:])) == 10
+    assert query.__contains__("LIMIT")
+
+
 def test_dataframe_display_repr(db: gp.Database):
     # fmt: off
     rows = [(1, 1, "Lion",), (2, 2, "Tiger",), (3, 3, "Wolf",), (4, 4, "Fox")]

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -65,7 +65,7 @@ def test_dataframe_getitem_slice_off_limit(db: gp.Database, t: gp.DataFrame):
 def test_dataframe_getitem_slice_off_limit(db: gp.Database, t: gp.DataFrame):
     query = t[:]._build_full_query()
     assert len(list(t[:])) == 10
-    assert query.__contains__("LIMIT")
+    assert "LIMIT" in query
 
 
 def test_dataframe_display_repr(db: gp.Database):


### PR DESCRIPTION
This patch fixes the following issue when selecting an entire 
dataframe with slice doesn't contain a LIMIT clause in the query.