### PR TITLE
Add distribution key for saving dataframe in db

### DIFF
--- a/greenplumpython/dataframe.py
+++ b/greenplumpython/dataframe.py
@@ -877,8 +877,8 @@ class DataFrame:
             storage_params: storage_parameter of gpdb, reference
                 https://docs.vmware.com/en/VMware-Tanzu-Greenplum/7/greenplum-database/GUID-ref_guide-sql_commands-CREATE_TABLE_AS.html
             schema: schema of the table for avoiding name conflicts.
-            distribution_type: method of distribution by.
-            distribution_keys: list of distribution keys.
+            distribution_type: type of distribution by.
+            distribution_key: distribution key.
 
         Returns:
             DataFrame : :class:`~dataframe.DataFrame` represents the newly saved table

--- a/greenplumpython/dataframe.py
+++ b/greenplumpython/dataframe.py
@@ -859,6 +859,8 @@ class DataFrame:
         temp: bool = False,
         storage_params: dict[str, Any] = {},
         schema: Optional[str] = None,
+        distribution_method: Literal[None, "randomly", "replicated", "keys"] = None,
+        distribution_keys: Optional[List[str]] = None,
     ) -> "DataFrame":
         """
         Save the GreenplumPython :class:`~dataframe.Dataframe` as a *table* into the database.
@@ -875,6 +877,8 @@ class DataFrame:
             storage_params: storage_parameter of gpdb, reference
                 https://docs.vmware.com/en/VMware-Tanzu-Greenplum/7/greenplum-database/GUID-ref_guide-sql_commands-CREATE_TABLE_AS.html
             schema: schema of the table for avoiding name conflicts.
+            distribution_method: method of distribution by.
+            distribution_keys: list of distribution keys.
 
         Returns:
             DataFrame : :class:`~dataframe.DataFrame` represents the newly saved table
@@ -919,12 +923,22 @@ class DataFrame:
             f"WITH ({','.join([f'{key}={storage_params[key]}' for key in storage_params.keys()])})"
         )
         df_full_name = f'"{table_name}"' if schema is None else f'"{schema}"."{table_name}"'
+        distribution_clause = (
+            f"""
+                DISTRIBUTED {f"BY ({','.join(distribution_keys)})" 
+                if distribution_method == "keys" 
+                else "REPLICATED"}
+            """
+            if distribution_method is not None
+            else ""
+        )
         self._db._execute(
             f"""
             CREATE {'TEMP' if temp else ''} TABLE {df_full_name}
             ({','.join(column_names)})
             {storage_parameters if storage_params else ''}
             AS {self._build_full_query()}
+            {distribution_clause}
             """,
             has_results=False,
         )

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -400,17 +400,11 @@ def test_table_distributed_randomly(db: gp.Database):
         temp=True,
         distribution_type="randomly",
     )
-    query = f"""select 
-                pg_get_table_distributedby(c.oid) distributedby
-                from pg_class as c
-                inner join pg_namespace as n
-                on c.relnamespace = n.oid
-                where n.nspname like 'pg_temp%'
-                and c.relname = 'randomly_dataframe';
-            """
+    query = f"""select pg_get_table_distributedby('"pg_temp"."randomly_dataframe"'::regclass) distributedby"""
     result = db._execute(query)
     for row in result:
         assert row["distributedby"] == "DISTRIBUTED RANDOMLY"
+    db._execute("DROP TABLE pg_temp.randomly_dataframe", has_results=False)
 
 
 def test_table_distributed_replicated(db: gp.Database):
@@ -432,14 +426,7 @@ def test_table_distributed_replicated(db: gp.Database):
         temp=True,
         distribution_type="replicated",
     )
-    query = f"""select 
-                pg_get_table_distributedby(c.oid) distributedby
-                from pg_class as c
-                inner join pg_namespace as n
-                on c.relnamespace = n.oid
-                where n.nspname like 'pg_temp%'
-                and c.relname = 'replicated_dataframe';
-            """
+    query = f"""select pg_get_table_distributedby('"pg_temp"."replicated_dataframe"'::regclass) distributedby"""
     result = db._execute(query)
     for row in result:
         assert row["distributedby"] == "DISTRIBUTED REPLICATED"
@@ -459,20 +446,13 @@ def test_table_distributed_hash(db: gp.Database):
     t = db.assign(id=lambda: generate_series(0, 9))
     # pass if no error
     t.save_as(
-        "replicated_dataframe",
+        "hash_dataframe",
         column_names=["id"],
         temp=True,
         distribution_type="hash",
         distribution_key={"id"},
     )
-    query = f"""select 
-                pg_get_table_distributedby(c.oid) distributedby
-                from pg_class as c
-                inner join pg_namespace as n
-                on c.relnamespace = n.oid
-                where n.nspname like 'pg_temp%'
-                and c.relname = 'replicated_dataframe';
-            """
+    query = f"""select pg_get_table_distributedby('"pg_temp"."hash_dataframe"'::regclass) distributedby"""
     result = db._execute(query)
     for row in result:
         assert row["distributedby"] == "DISTRIBUTED BY (id)"


### PR DESCRIPTION
Greenplum has a MPP architecture, so it relies on distribution 
of data across segments. This patch supports defining distribution 
type and distribution key of table when saving Dataframe to GPDB.