### PR TITLE
Fix rocky8 pipeline for merge

### DIFF
--- a/concourse/pipeline/commit.yml
+++ b/concourse/pipeline/commit.yml
@@ -4,7 +4,7 @@
 #@   "centos7_gpdb6_conf",
 #@   "ubuntu18_gpdb6_conf",
 #@   "rhel8_gpdb6_conf",
-#@   "rocky8_gpdb7_conf",
+#@   "el8_gpdb7_conf",
 #@ )
 #@ load("trigger_def.lib.yml",
 #@   "commit_trigger",
@@ -18,7 +18,7 @@
 #@   rhel8_gpdb6_conf(),
 #@   centos7_gpdb6_conf(),
 #@   ubuntu18_gpdb6_conf(),
-#@   rocky8_gpdb7_conf(),
+#@   el8_gpdb7_conf(),
 #@ ]
 jobs:
 #@ param = {

--- a/concourse/pipeline/dev.yml
+++ b/concourse/pipeline/dev.yml
@@ -4,7 +4,7 @@
 #@   "centos7_gpdb6_conf",
 #@   "ubuntu18_gpdb6_conf",
 #@   "rhel8_gpdb6_conf",
-#@   "rocky8_gpdb7_conf")
+#@   "el8_gpdb7_conf")
 #@
 #@ load("trigger_def.lib.yml",
 #@   "commit_dev_trigger",
@@ -16,7 +16,7 @@
 #@ trigger = commit_dev_trigger(res_map)
 #@ confs= [
 #@   rhel8_gpdb6_conf(release_build=False),
-#@   rocky8_gpdb7_conf(release_build=False)
+#@   el8_gpdb7_conf(release_build=False)
 #@ ]
 jobs:
 #@ param = {

--- a/concourse/pipeline/job_def.lib.yml
+++ b/concourse/pipeline/job_def.lib.yml
@@ -32,13 +32,13 @@ res_plpython3_bin: bin_plpython3_gpdb6_ubuntu18
 os: ubuntu1804
 #@ end
 
-#! Job config for gpdb7 rocky8
-#@ def rocky8_gpdb7_conf(release_build=False):
+#! Job config for gpdb7 el8
+#@ def el8_gpdb7_conf(release_build=False):
 res_test_image: rhel8-gpdb7-image-test
-res_gpdb_bin: #@ "bin_gpdb7_rocky8" + ("" if release_build else "_debug")
+res_gpdb_bin: #@ "bin_gpdb7_el8" + ("" if release_build else "_debug")
 res_gpdb_src: gpdb7_src
 gpdb_version: gpdb7
-os: rocky8
+os: el8
 #@ end
 
 #! The entry point of a pipeline. The job name must be 'entrance'.

--- a/concourse/pipeline/pr.yml
+++ b/concourse/pipeline/pr.yml
@@ -5,7 +5,7 @@
 #@   "centos7_gpdb6_conf",
 #@   "rhel8_gpdb6_conf",
 #@   "ubuntu18_gpdb6_conf",
-#@   "rocky8_gpdb7_conf",
+#@   "el8_gpdb7_conf",
 #@ )
 #@ load("trigger_def.lib.yml",
 #@   "pr_trigger",
@@ -20,7 +20,7 @@
 #@   centos7_gpdb6_conf(),
 #@   rhel8_gpdb6_conf(),
 #@   ubuntu18_gpdb6_conf(),
-#@   rocky8_gpdb7_conf(),
+#@   el8_gpdb7_conf(),
 #@ ]
 jobs:
 #@ param = {

--- a/concourse/pipeline/release.yml
+++ b/concourse/pipeline/release.yml
@@ -5,7 +5,7 @@
 #@   "centos7_gpdb6_conf",
 #@   "rhel8_gpdb6_conf",
 #@   "ubuntu18_gpdb6_conf",
-#@   "rocky8_gpdb7_conf",
+#@   "el8_gpdb7_conf",
 #@ )
 #@ load("trigger_def.lib.yml",
 #@   "release_trigger",
@@ -19,7 +19,7 @@
 #@   centos7_gpdb6_conf(release_build=True),
 #@   rhel8_gpdb6_conf(release_build=True),
 #@   ubuntu18_gpdb6_conf(release_build=True),
-#@   rocky8_gpdb7_conf(release_build=True),
+#@   el8_gpdb7_conf(release_build=True),
 #@ ]
 jobs:
 #@ param = {

--- a/concourse/pipeline/res_def.yml
+++ b/concourse/pipeline/res_def.yml
@@ -117,12 +117,12 @@ resources:
     bucket: pivotal-gpdb-concourse-resources-prod
     json_key: ((concourse-gcs-resources-service-account-key))
     regexp: server/published/gpdb6/server-rc-(.*)-ubuntu18.04_x86_64.tar.gz
-- name: bin_gpdb7_rocky8_debug
+- name: bin_gpdb7_el8_debug
   type: gcs
   source:
     bucket: pivotal-gpdb-concourse-resources-prod
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/published/main/server-rc-(.*)-rocky8_x86_64.debug.tar.gz
+    regexp: server/published/main/server-rc-(.*)-el8_x86_64.debug.tar.gz
 
 # plpython3 for gpdb6
 - name: bin_plpython3_gpdb6_rhel7


### PR DESCRIPTION
The latest binary version for rocky8 is GP7-beta1, 
this patch replaces rocky8 to el8 to obtain recent 
version.