### PR TITLE
Replace gp_segment_id with UDF

### DIFF
--- a/doc/source/notebooks/abalone.ipynb
+++ b/doc/source/notebooks/abalone.ipynb
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -417,14 +417,15 @@
     }
    ],
    "source": [
-    "# SELECT gp_segment_id, COUNT(*)\n",
+    "# SELECT gp_execution_segment() AS gp_segment_id, COUNT(*)\n",
     "# FROM abalone\n",
-    "# GROUP BY 1\n",
-    "# ORDER BY gp_segment_id;\n",
+    "# GROUP BY 1;\n",
     "\n",
     "import greenplumpython.builtins.functions as F\n",
     "\n",
-    "abalone.group_by(\"gp_segment_id\").apply(lambda _: F.count())"
+    "abalone.assign(gp_segment_id=lambda _: gp.function(\"gp_execution_segment\")()).group_by(\n",
+    "    \"gp_segment_id\"\n",
+    ").apply(lambda _: F.count())"
    ]
   },
   {


### PR DESCRIPTION
Since commit 6467882a, access to gp_segment_id is explicitly disabled. (Before the PR they can be accessed just "by accident") This is because they are too limited and only valid for "regular tables".

This patch replaces gp_segment_id with UDF gp_execution_segment(). The latter can be applied on not only regular tables, but also queries. Therefore, it is more general than gp_segment_id