### PR TITLE
Support Existing Table Column Information

### DIFF
--- a/greenplumpython/dataframe.py
+++ b/greenplumpython/dataframe.py
@@ -973,21 +973,6 @@ class DataFrame:
             if drop_if_exists
             else ""
         )
-        # if temp:
-        #     temp_schema_name = next(
-        #         iter(
-        #             (
-        #                 self._db._execute(
-        #                     f"""
-        #             SELECT DISTINCT 'pg_temp_'||sess_id temp_schema
-        #             FROM pg_stat_activity
-        #             WHERE pid = pg_backend_pid();
-        #         """,
-        #                     has_results=True,
-        #                 )
-        #             )
-        #         )
-        #     )["temp_schema"]
         self._db._execute(
             f"""
             DO $$

--- a/greenplumpython/dataframe.py
+++ b/greenplumpython/dataframe.py
@@ -1141,21 +1141,10 @@ class DataFrame:
 
         """
         qualified_name = f'"{schema}"."{table_name}"' if schema is not None else f'"{table_name}"'
-        table_schema_clause = (
-            (
-                " AND table_schema "
-                + (f"""like '{schema}_%'""" if schema == "pg_temp" else f"""= '{schema}'""")
-            )
-            if schema
-            else ""
-        )
-
-        # table_schema_clause = f""" AND table_schema like '{schema}_%'""" if schema = "pg_temp" else if schema else ""
         columns_query = f"""
-                SELECT column_name, data_type 
-                FROM information_schema.columns 
-                WHERE table_name = '{table_name}' {table_schema_clause}
-                ORDER BY ordinal_position
+                SELECT attname AS column_name, atttypid::regtype AS data_type
+                FROM pg_attribute 
+                WHERE attrelid = '{qualified_name}'::regclass and attnum > 0;
         """
         columns_inf_result = list(db._execute(columns_query, has_results=True))  # type: ignore reportUnknownVariableType
         assert columns_inf_result, f"Table {qualified_name} does not exists"

--- a/greenplumpython/dataframe.py
+++ b/greenplumpython/dataframe.py
@@ -1267,7 +1267,7 @@ class DataFrame:
 
     def describe(self) -> dict[str, str]:
         """
-        Returns a dictionary summarising the column information of the dataframe, conditional on the table existing in the database.
+        Return a dictionary summarising the column information of the dataframe, conditional on the table existing in the database.
 
         Returns:
             Dictionary containing the column names and types.

--- a/greenplumpython/dataframe.py
+++ b/greenplumpython/dataframe.py
@@ -1267,8 +1267,7 @@ class DataFrame:
 
     def describe(self) -> dict[str, str]:
         """
-        Returns a dictionary summarising the column information of the dataframe,
-        conditional on the table existing in the database.
+        Returns a dictionary summarising the column information of the dataframe, conditional on the table existing in the database.
 
         Returns:
             Dictionary containing the column names and types.

--- a/greenplumpython/dataframe.py
+++ b/greenplumpython/dataframe.py
@@ -1157,15 +1157,15 @@ class DataFrame:
                 WHERE table_name = '{table_name}' {table_schema_clause}
                 ORDER BY ordinal_position
         """
-        columns_inf_result = list(db._execute(columns_query, has_results=True))
+        columns_inf_result = list(db._execute(columns_query, has_results=True))  # type: ignore reportUnknownVariableType
         assert columns_inf_result, f"Table {qualified_name} does not exists"
-        columns_list = {d["column_name"]: d["data_type"] for d in columns_inf_result}
+        columns_list: dict[str, str] = {d["column_name"]: d["data_type"] for d in columns_inf_result}  # type: ignore reportUnknownVariableType
         return cls(
             f"TABLE {qualified_name}",
             db=db,
             qualified_table_name=qualified_name,
             columns=columns_list,
-        )
+        )  # type: ignore reportUnknownVariableType
 
     @classmethod
     def from_rows(

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -506,3 +506,20 @@ def test_const_non_ascii(db: gp.Database):
     df = db.create_dataframe(columns={"Ø": ["Ø"]})
     for row in df[["Ø"]]:
         assert row["Ø"] == "Ø"
+
+
+def test_table_describe(db: gp.Database):
+    df = db.create_dataframe(table_name="pg_class")
+    result = df.describe()
+    assert len(result) == 33
+    df_not_exist = db.create_dataframe(table_name="not_exist_table")
+    with pytest.raises(Exception) as exc_info:
+        df_not_exist.describe()
+    assert 'relation "not_exist_table" does not exist' in str(exc_info.value)
+
+
+def test_dataframe_describe(db: gp.Database):
+    df = db.create_dataframe(table_name="pg_class")[["relname", "relnamespace"]]
+    with pytest.raises(Exception) as exc_info:
+        df.describe()
+    assert "Dataframe is not saved in database" in str(exc_info.value)

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -478,7 +478,7 @@ def test_table_distributed_hash(db: gp.Database):
 def test_table_describe(db: gp.Database):
     columns = {"a": [1, 2, 3], "b": [1, 2, 3]}
     t = db.create_dataframe(columns=columns)
-    df = t.save_as("const_dataframe", column_names=["a", "b"], schema="test")
+    df = t.save_as("const_table_describe", column_names=["a", "b"], schema="test")
     result = df.describe()
     assert len(result) == 2
     df_s = df[["a", "b"]]

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -475,6 +475,22 @@ def test_table_distributed_hash(db: gp.Database):
         assert row["distributedby"] == "DISTRIBUTED BY (id)"
 
 
+def test_table_describe(db: gp.Database):
+    columns = {"a": [1, 2, 3], "b": [1, 2, 3]}
+    t = db.create_dataframe(columns=columns)
+    df = t.save_as("const_dataframe", column_names=["a", "b"], schema="test")
+    result = df.describe()
+    assert len(result) == 2
+    df_s = df[["a", "b"]]
+    with pytest.raises(Exception) as exc_info:
+        df_s.describe()
+    assert "Dataframe is not saved in database" in str(exc_info.value)
+    df_not_exist = db.create_dataframe(table_name="not_exist_table")
+    with pytest.raises(Exception) as exc_info:
+        df_not_exist.describe()
+    assert 'relation "not_exist_table" does not exist' in str(exc_info.value)
+
+
 import pandas as pd
 
 
@@ -506,20 +522,3 @@ def test_const_non_ascii(db: gp.Database):
     df = db.create_dataframe(columns={"Ø": ["Ø"]})
     for row in df[["Ø"]]:
         assert row["Ø"] == "Ø"
-
-
-def test_table_describe(db: gp.Database):
-    df = db.create_dataframe(table_name="pg_class")
-    result = df.describe()
-    assert len(result) == 33
-    df_not_exist = db.create_dataframe(table_name="not_exist_table")
-    with pytest.raises(Exception) as exc_info:
-        df_not_exist.describe()
-    assert 'relation "not_exist_table" does not exist' in str(exc_info.value)
-
-
-def test_dataframe_describe(db: gp.Database):
-    df = db.create_dataframe(table_name="pg_class")[["relname", "relnamespace"]]
-    with pytest.raises(Exception) as exc_info:
-        df.describe()
-    assert "Dataframe is not saved in database" in str(exc_info.value)


### PR DESCRIPTION
So far, we don't have any information about the DataFrame's 
columns and their types. This patch supports retrieving column 
information of an existing table in the database. 
Moreover, adds a table check when creating a DataFrame from table, 
so that the user can catch the name error early.